### PR TITLE
[FEATURE] allow PageTSconfig option to filter for mappings

### DIFF
--- a/Classes/Service/ItemsProcFunc.php
+++ b/Classes/Service/ItemsProcFunc.php
@@ -97,11 +97,9 @@ class ItemsProcFunc
     {
         if (isset($tvpPageTsConfig['filterMaps.'])) {
             $allowedPlaces = $tvpPageTsConfig['filterMaps.'];
-        }
-        elseif (isset($tvpPageTsConfig['filterMaps'])) {
+        } elseif (isset($tvpPageTsConfig['filterMaps'])) {
             $allowedPlaces[] = $tvpPageTsConfig['filterMaps'];
-        }
-        else {
+        } else {
             return true;
         }
 

--- a/Configuration/TSConfig/Page.ts
+++ b/Configuration/TSConfig/Page.ts
@@ -4,13 +4,3 @@ mod.web_txtemplavoilaplusLayout.enableContentAccessWarning = 1
 mod.web_txtemplavoilaplusLayout.enableLocalizationLinkForFCEs = 0
 mod.web_txtemplavoilaplusLayout.useLiveWorkspaceForReferenceListUpdates = 1
 mod.web_txtemplavoilaplusLayout.adminOnlyPageStructureInheritance = fallback
-
-# example for filtering allowed maps allow single string or array
-# refers to mappingconfiguration identifier, so look for the prefix in
-# yourextenstion/Configuration/TVP/MappingPlaces.php for an identifier like
-# vendor/yourextension/Page/MappingConfiguration
-# and use that like:
-# mod.web_txtemplavoilaplusLayout.filterMaps = vendor/yourextension
-# or like:
-# mod.web_txtemplavoilaplusLayout.filterMaps.1 = vendor/yourextension/Page
-# mod.web_txtemplavoilaplusLayout.filterMaps.2 = vendor/yourotherextension/FCE

--- a/Configuration/TSConfig/Page.ts
+++ b/Configuration/TSConfig/Page.ts
@@ -4,3 +4,13 @@ mod.web_txtemplavoilaplusLayout.enableContentAccessWarning = 1
 mod.web_txtemplavoilaplusLayout.enableLocalizationLinkForFCEs = 0
 mod.web_txtemplavoilaplusLayout.useLiveWorkspaceForReferenceListUpdates = 1
 mod.web_txtemplavoilaplusLayout.adminOnlyPageStructureInheritance = fallback
+
+# example for filtering allowed maps allow single string or array
+# refers to mappingconfiguration identifier, so look for the prefix in
+# yourextenstion/Configuration/TVP/MappingPlaces.php for an identifier like
+# vendor/yourextension/Page/MappingConfiguration
+# and use that like:
+# mod.web_txtemplavoilaplusLayout.filterMaps = vendor/yourextension
+# or like:
+# mod.web_txtemplavoilaplusLayout.filterMaps.1 = vendor/yourextension/Page
+# mod.web_txtemplavoilaplusLayout.filterMaps.2 = vendor/yourotherextension/FCE


### PR DESCRIPTION
This will allow easier supplying of sitepackages, as you can filter
mappings by page branch easily. Most template extension will provide
mappings as well as PageTSconfig, so with this you can easily do a

mod.web_txtemplavoilaplusLayout.filterMaps = vendor/yourextension

to not show other mappings in that branch. Thus allowing
multi-template-setups easily, while still retaining the access check
and thus allowing editors for different templates to not mix them up,
as we can now filter by page tree as well as user.

As there might be extension supplying FCEs only (e.g. bootstrap style
containers). there is an option to define an array of allowed stuff
like

mod.web_txtemplavoilaplusLayout.filterMaps.1 = vendor/yourextension/Page
mod.web_txtemplavoilaplusLayout.filterMaps.2 = vendor/yourotherextension/FCE