### PR TITLE
[TASK] allow php8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
           - 7.2
           - 7.3
           - 7.4
-#          - 8.0
-#          - 8.1
+          - 8.0
+          - 8.1
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-20.04
@@ -162,18 +162,18 @@ jobs:
           - typo3-version: ^11.5
             php-version: 7.4
             composer-dependencies: lowest
-#          - typo3-version: ^11.5
-#            php-version: 8.0
-#            composer-dependencies: highest
-#          - typo3-version: ^11.5
-#            php-version: 8.0
-#            composer-dependencies: lowest
-#          - typo3-version: ^11.5
-#            php-version: 8.1
-#            composer-dependencies: highest
-#          - typo3-version: ^11.5
-#            php-version: 8.1
-#            composer-dependencies: lowest
+          - typo3-version: ^11.5
+            php-version: 8.0
+            composer-dependencies: highest
+          - typo3-version: ^11.5
+            php-version: 8.0
+            composer-dependencies: lowest
+          - typo3-version: ^11.5
+            php-version: 8.1
+            composer-dependencies: highest
+          - typo3-version: ^11.5
+            php-version: 8.1
+            composer-dependencies: lowest
   functional-tests:
     name: "Functional tests"
     runs-on: ubuntu-18.04
@@ -249,15 +249,15 @@ jobs:
           - typo3-version: ^11.5
             php-version: 7.4
             composer-dependencies: lowest
-#          - typo3-version: ^11.5
-#            php-version: 8.0
-#            composer-dependencies: highest
-#          - typo3-version: ^11.5
-#            php-version: 8.0
-#            composer-dependencies: lowest
-#          - typo3-version: ^11.5
-#            php-version: 8.1
-#            composer-dependencies: highest
-#          - typo3-version: ^11.5
-#            php-version: 8.1
-#            composer-dependencies: lowest
+          - typo3-version: ^11.5
+            php-version: 8.0
+            composer-dependencies: highest
+          - typo3-version: ^11.5
+            php-version: 8.0
+            composer-dependencies: lowest
+          - typo3-version: ^11.5
+            php-version: 8.1
+            composer-dependencies: highest
+          - typo3-version: ^11.5
+            php-version: 8.1
+            composer-dependencies: lowest

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	],
 	"homepage": "https://templavoila.plus/",
 	"require": {
-		"php": ">=7.2.0 <7.4.99",
+		"php": ">=7.2.0 <8.1.99",
 		"typo3/cms-core": "^8.7.0 || ^9.5.0 || ^10.4.0 || ^11.5.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
This is a WIP - for the time being it will just enable the CI tests for php 8 and 8.1 support and change the composer.json to allow those php versions, too.

This will be regularly rebased to reflect the changes to the codebase. 