### PR TITLE
[BUGFIX] unhandled type exception if deleted page needs map resolving during refindex update

### DIFF
--- a/Classes/Configuration/FlexForm/DataStructureIdentifierHook.php
+++ b/Classes/Configuration/FlexForm/DataStructureIdentifierHook.php
@@ -20,8 +20,6 @@ namespace Tvp\TemplaVoilaPlus\Configuration\FlexForm;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use Tvp\TemplaVoilaPlus\Domain\Model\DataStructure;
-use Tvp\TemplaVoilaPlus\Domain\Model\MappingConfiguration;
 use Tvp\TemplaVoilaPlus\Exception\ConfigurationException;
 use Tvp\TemplaVoilaPlus\Utility\ApiHelperUtility;
 
@@ -30,6 +28,8 @@ class DataStructureIdentifierHook
     /**
      * Hook class method parseDataStructureByIdentifierPreProcess must either return an empty string or a data structure
      * string or a parsed data structure array.
+     *
+     * @throws \RuntimeException
      */
     public function parseDataStructureByIdentifierPreProcess(array $identifier)
     {
@@ -59,7 +59,7 @@ class DataStructureIdentifierHook
                 $dataStructure = ApiHelperUtility::getDataStructure($mappingConfiguration->getCombinedDataStructureIdentifier());
 
                 $dataStructure = $dataStructure->getDataStructureArray();
-            } catch (ConfigurationException $e) {
+            } catch (ConfigurationException | \TypeError $e) {
                 $dataStructure = ['error' => $e->getMessage()];
                 /** @TODO Do logging, if we cannot found the Mapping or DS? */
             }


### PR DESCRIPTION
I called `vendor/bin/typo3cms referenceindex:update` and during that `DataStructureIdentifierHook::parseDataStructureByIdentifierPreProcess()` resolves the map of pages.

However in case of a deleted page the `dataStructure` retrieved is no `string` or `emptyString`, but just false, since the `queryBuilder` won't look up deleted pages (for good reason). However this `false` creates a `\TypeError` as `getConfiguration` expects a `string`. 
In order to not change any logic, but solve this problem this `TypeError` should just be handled like a normal `ConfigurationException`