### PR TITLE
[TASK] Add conditional logging and exceptions for missing tt_content mapping

### DIFF
--- a/Classes/Exception/ContentElementWithoutMapException.php
+++ b/Classes/Exception/ContentElementWithoutMapException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tvp\TemplaVoilaPlus\Exception;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * An exception which represents an error in the DataStructure.
+ */
+class ContentElementWithoutMapException extends \TYPO3\CMS\Core\Exception
+{
+}


### PR DESCRIPTION
Currently "broken" tt_content elements (e.g. FCE without mapping) are just returned as emptyString to not break whole page output.

This patch adds the logging functionality marked as TODO and adds conditional output so that 

- on production systems still the current behaviour (no output) is done
- on non-production systems (FE debug enabled) the exception is thrown

Additionally the Exception for FCE without mapping is now named explicitly.