### PR TITLE
[REGRESSION] re-introduce the REGISTER tx_templavoilaplus_pi1.current_field

### DIFF
--- a/Classes/Handler/Mapping/DefaultMappingHandler.php
+++ b/Classes/Handler/Mapping/DefaultMappingHandler.php
@@ -57,6 +57,10 @@ class DefaultMappingHandler
             $processedValue = $instructions['value'];
         }
 
+        if (isset($instructions['dataPath'])) {
+            $GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field'] = $instructions['dataPath'];
+        }
+
         switch ($instructions['dataType']) {
             case 'row':
                 if (isset($row[$instructions['dataPath']])) {
@@ -64,13 +68,12 @@ class DefaultMappingHandler
                 }
                 break;
             case 'flexform':
-                $GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field'] = $instructions['dataPath'];
                 if (isset($flexformData[$instructions['dataPath']])) {
                     $processedValue = $flexformData[$instructions['dataPath']] ?? '';
                 }
                 break;
             case 'typoscriptObjectPath':
-                list($name, $conf) = $this->getTypoScriptParser()->getVal($instructions['dataPath'], $GLOBALS['TSFE']->tmpl->setup);
+                [$name, $conf] = $this->getTypoScriptParser()->getVal($instructions['dataPath'], $GLOBALS['TSFE']->tmpl->setup);
                 $processedValue = $this->getContentObjectRenderer($flexformData, $processedValue, $table, $row)->cObjGetSingle($name, $conf, 'TemplaVoila_ProcObjPath--' . str_replace('.', '*', $instructions['dataPath']) . '.');
                 break;
             default:

--- a/Classes/Handler/Mapping/DefaultMappingHandler.php
+++ b/Classes/Handler/Mapping/DefaultMappingHandler.php
@@ -64,6 +64,7 @@ class DefaultMappingHandler
                 }
                 break;
             case 'flexform':
+                $GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field'] = $instructions['dataPath'];
                 if (isset($flexformData[$instructions['dataPath']])) {
                     $processedValue = $flexformData[$instructions['dataPath']] ?? '';
                 }
@@ -94,7 +95,7 @@ class DefaultMappingHandler
             default:
                 // No valueProcessing given, so no value manipulation
         }
-
+        unset($GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field']);
         return $processedValue;
     }
 


### PR DESCRIPTION
During the refactoring the REGISTERs `tx_templavoilaplus_pi1.parentRec.*` where re-introduced. However in old TVPv7 there was a  REGISTER `tx_templavoilaplus_pi1.current_field`, too.

As it doesn't create unnecessary load and this context information might help for output styling, it is re-introduced with this patch. The register holds the parent field (e.g. the page flex form field name, or the FCE flex form field name).