### PR TITLE
[REGRESSION] FEcontroller needs to call parent __construct

### DIFF
--- a/Classes/Controller/Frontend/FrontendController.php
+++ b/Classes/Controller/Frontend/FrontendController.php
@@ -42,6 +42,7 @@ class FrontendController extends AbstractPlugin
 
     public function __construct()
     {
+        AbstractPlugin::__construct();
         $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(self::class);
     }
 


### PR DESCRIPTION
While introducing the logger, this call wasn't done, thus omiting the typical AbstractPlugin init.