### PR TITLE
[FEATURE] allow old TypoScript page userfunc

### DIFF
--- a/Classes/Controller/Frontend/FrontendController.php
+++ b/Classes/Controller/Frontend/FrontendController.php
@@ -47,6 +47,19 @@ class FrontendController extends AbstractPlugin
     }
 
     /**
+     * @param string $content Standard content input. Ignore.
+     * @param array $conf TypoScript array for the plugin.
+     *
+     * @return string HTML content for the Flexible Content elements.
+     * @deprecated Starting with v8 you should call renderPage directly via TypoScript
+     *             page.10.userFunc = Tvp\TemplaVoilaPlus\Controller\Frontend\FrontendController->renderPage
+     */
+    public function main_page($content, $conf)
+    {
+        return $this->renderPage($content, $conf);
+    }
+
+    /**
      * Main function for rendering of Flexible Content elements of TemplaVoila
      *
      * @param string $content Standard content input. Ignore.

--- a/Classes/Controller/Frontend/FrontendController.php
+++ b/Classes/Controller/Frontend/FrontendController.php
@@ -60,7 +60,7 @@ class FrontendController extends AbstractPlugin
         // phpcs:enable
         trigger_error(
             'Deprecated TypoScript page userFunc for EXT:templavoilaplus ' .
-            '"Ppi\\TemplaVoilaPlus\\Controller|\FrontendController->main_page" was found, ' .
+            '"Ppi\\TemplaVoilaPlus\\Controller\\FrontendController->main_page" was found, ' .
             'please change to "Tvp\TemplaVoilaPlus\Controller\Frontend\FrontendController->renderPage"',
             E_USER_DEPRECATED
         );

--- a/Classes/Controller/Frontend/FrontendController.php
+++ b/Classes/Controller/Frontend/FrontendController.php
@@ -54,8 +54,16 @@ class FrontendController extends AbstractPlugin
      * @deprecated Starting with v8 you should call renderPage directly via TypoScript
      *             page.10.userFunc = Tvp\TemplaVoilaPlus\Controller\Frontend\FrontendController->renderPage
      */
+    // phpcs:disable
     public function main_page($content, $conf)
     {
+        // phpcs:enable
+        trigger_error(
+            'Deprecated TypoScript page userFunc for EXT:templavoilaplus ' .
+            '"Ppi\\TemplaVoilaPlus\\Controller|\FrontendController->main_page" was found, ' .
+            'please change to "Tvp\TemplaVoilaPlus\Controller\Frontend\FrontendController->renderPage"',
+            E_USER_DEPRECATED
+        );
         return $this->renderPage($content, $conf);
     }
 

--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -1,5 +1,5 @@
 <?php
 return [
-    'Ppi\\TemplaVoilaPlus\\Controller|\FrontendController' => \Tvp\TemplaVoilaPlus\Controller\FrontendController::class,
-    'Ppi\\TemplaVoilaPlus\\Controller|\SectionIndexController' => \Tvp\TemplaVoilaPlus\Controller\SectionIndexController::class
+    'Ppi\\TemplaVoilaPlus\\Controller\\FrontendController' => \Tvp\TemplaVoilaPlus\Controller\FrontendController::class,
+    'Ppi\\TemplaVoilaPlus\\Controller\\SectionIndexController' => \Tvp\TemplaVoilaPlus\Controller\SectionIndexController::class
 ];

--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -1,5 +1,6 @@
 <?php
+
 return [
-    'Ppi\\TemplaVoilaPlus\\Controller\\FrontendController' => \Tvp\TemplaVoilaPlus\Controller\FrontendController::class,
+    'Ppi\\TemplaVoilaPlus\\Controller\\FrontendController' => \Tvp\TemplaVoilaPlus\Controller\Frontend\FrontendController::class,
     'Ppi\\TemplaVoilaPlus\\Controller\\SectionIndexController' => \Tvp\TemplaVoilaPlus\Controller\SectionIndexController::class
 ];

--- a/Migrations/Code/ClassAliasMap.php
+++ b/Migrations/Code/ClassAliasMap.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'Ppi\\TemplaVoilaPlus\\Controller|\FrontendController' => \Tvp\TemplaVoilaPlus\Controller\FrontendController::class,
+    'Ppi\\TemplaVoilaPlus\\Controller|\SectionIndexController' => \Tvp\TemplaVoilaPlus\Controller\SectionIndexController::class
+];

--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,11 @@
 		"vendor-dir": ".Build/vendor"
 	},
 	"extra": {
+		"typo3/class-alias-loader": {
+			"class-alias-maps": [
+				"Migrations/Code/ClassAliasMap.php"
+			]
+		},
 		"typo3/cms": {
 			"app-dir": ".Build",
 			"extension-key": "templavoilaplus",


### PR DESCRIPTION
During the switch to v8 the namespace changed, thus it is advised to change the TypoScript after the migration from
```
page.10.userFunc = Ppi\TemplaVoilaPlus\Controller\FrontendController->main_page
tt_content.menu.20.3.userFunc =  Ppi\TemplaVoilaPlus\Controller\SectionIndexController->mainAction
```
to
```
page.10.userFunc = Tvp\TemplaVoilaPlus\Controller\Frontend\FrontendController->renderPage
tt_content.menu.20.3.userFunc = Tvp\TemplaVoilaPlus\Controller\SectionIndexController->mainAction
```

However by introducing the deprecated function name `main_page` and let it call renderPage and also adding a class-alias-map, this can be made optional, thus resulting in an even easier migration.