### PR TITLE
[REGRESSION] current_field REGISTER unset from flexform childs

### DIFF
--- a/Classes/Handler/Mapping/DefaultMappingHandler.php
+++ b/Classes/Handler/Mapping/DefaultMappingHandler.php
@@ -46,6 +46,7 @@ class DefaultMappingHandler
 
     public function valueProcessing(array $instructions, array $flexformData, string $table, array $row)
     {
+        $oldCurrentFieldRegister = $GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field'] ?? null;
         $processedValue = '';
 
         if (isset($instructions['value'])) {
@@ -96,7 +97,11 @@ class DefaultMappingHandler
             default:
                 // No valueProcessing given, so no value manipulation
         }
-        unset($GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field']);
+        if ($oldCurrentFieldRegister) {
+            $GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field'] = $oldCurrentFieldRegister;
+        } else {
+            unset($GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field']);
+        }
         return $processedValue;
     }
 


### PR DESCRIPTION
The PR https://github.com/T3Voila/templavoilaplus/pull/369 reintroduced the REGISTER `current_field`.

However the implementation was wrong as it just unsets the register after processing.
In case of e.g. a PAGE current_field `main_content` with flex form content elements, this leads to loosing the page current_field information as after the childs are processed it is unset.

Rather it needs to be reset to the value before starting the processing, to preserve the value.