### PR TITLE
[REGRESSION] backendLayout lookup won't respect rootline

### DIFF
--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -29,6 +29,7 @@ use TYPO3\CMS\Core\Database\RelationHandler;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 /**
  * ONLY FOR TEMPORARY USE
@@ -102,7 +103,7 @@ class ProcessingService
         $parentPointerString = $this->getParentPointerAsString($parentPointer);
         $combinedBackendLayoutConfigurationIdentifier = '';
 
-        $mappingConfiguration = $this->getMappingConfiguration($row);
+        $mappingConfiguration = $this->getMappingConfiguration($table, $row);
         if ($mappingConfiguration) {
             $combinedBackendLayoutConfigurationIdentifier = $mappingConfiguration->getCombinedBackendLayoutConfigurationIdentifier();
             if ($combinedBackendLayoutConfigurationIdentifier !== '') {
@@ -138,14 +139,21 @@ class ProcessingService
         return $node;
     }
 
-    public function getMappingConfiguration(array $row): ?MappingConfiguration
+    public function getMappingConfiguration(string $table, array $row): ?MappingConfiguration
     {
+        $map = $row['tx_templavoilaplus_map'];
         $mappingConfiguration = null;
 
-        if (isset($row['tx_templavoilaplus_map'])) {
+        // find mappingConfiguration in root line if current page doesn't have one
+        if (!$map && $table === 'pages') {
+            $apiService = GeneralUtility::makeInstance(ApiService::class, 'pages');
+            $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $row['uid'])->get();
+            $map = $apiService->getMapIdentifierFromRootline($rootLine);
+        }
+        if ($map) {
             try {
-                $mappingConfiguration = ApiHelperUtility::getMappingConfiguration($row['tx_templavoilaplus_map']);
-            } catch (ConfigurationException | MissingPlacesException | InvalidIdentifierException | \TypeError $e) {
+                $mappingConfiguration = ApiHelperUtility::getMappingConfiguration($map);
+            } catch (ConfigurationException|MissingPlacesException|InvalidIdentifierException|\TypeError $e) {
                 // Empty is correct
             }
         }


### PR DESCRIPTION
The page module checks `tx_templavoilaplus_map` for current page, but it should also traverse up in the roofline (like the `FrontendController`) in order to find parent mappings; else a subpage can't show the backend layout.

FWIW: `RootlineUtility` used is 8LTS compatible, thus no version dependant code addition.