### PR TITLE
Make CI tests green again

### DIFF
--- a/Classes/Controller/Backend/Ajax/ContentElements.php
+++ b/Classes/Controller/Backend/Ajax/ContentElements.php
@@ -56,7 +56,7 @@ class ContentElements extends AbstractResponse
                 [
                     'error' => $result
                 ],
-                400 // Bad request
+                400 /* Bad request */
             );
         }
     }
@@ -128,7 +128,7 @@ class ContentElements extends AbstractResponse
                 [
                     'error' => $result
                 ],
-                400 // Bad request
+                400 /* Bad request */
             );
         }
     }

--- a/Classes/Controller/Backend/ControlCenter/Update/AbstractUpdateController.php
+++ b/Classes/Controller/Backend/ControlCenter/Update/AbstractUpdateController.php
@@ -79,9 +79,6 @@ class AbstractUpdateController extends ActionController
         $this->assignDefault();
     }
 
-    /**
-     * @return string The HTML to be shown.
-     */
     public function assignDefault()
     {
         $this->view->assignMultiple([

--- a/Classes/Controller/Backend/ControlCenter/Update/DataStructureV11Controller.php
+++ b/Classes/Controller/Backend/ControlCenter/Update/DataStructureV11Controller.php
@@ -61,7 +61,8 @@ class DataStructureV11Controller extends AbstractUpdateController
     public function migrateSpecialLanguagesToTcaTypeLanguage(array &$element): bool
     {
         $changed = false;
-        if ((string)($element['TCEforms']['config']['type']) === 'select'
+        if (
+            (string)($element['TCEforms']['config']['type']) === 'select'
             && (string)($element['TCEforms']['config']['special']) === 'languages'
         ) {
             $element['TCEforms']['config'] = [
@@ -75,7 +76,8 @@ class DataStructureV11Controller extends AbstractUpdateController
     public function removeShowRemovedLocalizationRecords(array &$element): bool
     {
         $changed = false;
-        if ((string)($element['TCEforms']['config']['type']) === 'inline'
+        if (
+            (string)($element['TCEforms']['config']['type']) === 'inline'
             && isset($element['TCEforms']['config']['appearance']['showRemovedLocalizationRecords'])
         ) {
             unset($element['TCEforms']['config']['appearance']['showRemovedLocalizationRecords']);
@@ -91,7 +93,8 @@ class DataStructureV11Controller extends AbstractUpdateController
     public function migrateFileFolderConfiguration(array &$element): bool
     {
         $changed = false;
-        if ((string)($element['TCEforms']['config']['type']) === 'select'
+        if (
+            (string)($element['TCEforms']['config']['type']) === 'select'
             && isset($element['TCEforms']['config']['fileFolder'])
         ) {
             $element['TCEforms']['config']['fileFolderConfig'] = [
@@ -124,7 +127,8 @@ class DataStructureV11Controller extends AbstractUpdateController
     public function migrateLevelLinksPosition(array &$element): bool
     {
         $changed = false;
-        if ((string)($element['TCEforms']['config']['type']) === 'inline'
+        if (
+            (string)($element['TCEforms']['config']['type']) === 'inline'
             && (string)($element['TCEforms']['config']['appearance']['levelLinksPosition']) === 'none'
         ) {
             unset($element['TCEforms']['config']['appearance']['levelLinksPosition']);
@@ -143,7 +147,8 @@ class DataStructureV11Controller extends AbstractUpdateController
     public function migrateRootUidToStartingPoints(array &$element): bool
     {
         $changed = false;
-        if ((int)($element['TCEforms']['config']['treeConfig']['rootUid'] ?? 0) !== 0
+        if (
+            (int)($element['TCEforms']['config']['treeConfig']['rootUid'] ?? 0) !== 0
             && in_array((string)($element['TCEforms']['config']['type']), ['select', 'category'], true)
         ) {
             $element['TCEforms']['config']['treeConfig']['startingPoints'] = (string)(int)($element['TCEforms']['config']['treeConfig']['rootUid']);

--- a/Classes/Controller/Backend/ControlCenter/Update/DataStructureV8Controller.php
+++ b/Classes/Controller/Backend/ControlCenter/Update/DataStructureV8Controller.php
@@ -235,11 +235,11 @@ class DataStructureV8Controller extends AbstractUpdateController
         $changed = false;
 
         // Only handle select fields.
-        if (!empty($element['TCEforms']['config']['type'])
+        if (
+            !empty($element['TCEforms']['config']['type'])
             && $element['TCEforms']['config']['type'] === 'select'
             && empty($element['TCEforms']['config']['renderType'])
         ) {
-
             if (!empty($element['TCEforms']['config']['renderMode'])) {
                 switch ($element['TCEforms']['config']['renderMode']) {
                     case 'tree':
@@ -277,7 +277,8 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if (!empty($element['TCEforms']['config']['renderType'])
+        if (
+            !empty($element['TCEforms']['config']['renderType'])
             && $element['TCEforms']['config']['renderType'] !== 'selectSingle'
         ) {
             if (isset($element['TCEforms']['config']['noIconsBelowSelect'])) {
@@ -371,7 +372,8 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if (isset($element['TCEforms']['config']['renderType'])
+        if (
+            isset($element['TCEforms']['config']['renderType'])
             && $element['TCEforms']['config']['renderType'] === 'selectTree'
         ) {
             if (isset($element['TCEforms']['config']['treeConfig']['appearance']['width'])) {
@@ -435,7 +437,8 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if (isset($element['TCEforms']['config'])
+        if (
+            isset($element['TCEforms']['config'])
             && $element['TCEforms']['config']['type'] === 'check'
         ) {
             if (isset($element['TCEforms']['config']['showIfRTE'])) {
@@ -456,12 +459,14 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if ($element['TCEforms']['config']['type'] === 'input'
+        if (
+            $element['TCEforms']['config']['type'] === 'input'
             && !isset($element['TCEforms']['config']['renderType'])
         ) {
             $eval = $element['TCEforms']['config']['eval'] ?? '';
             $eval = GeneralUtility::trimExplode(',', $eval, true);
-            if (in_array('date', $eval, true)
+            if (
+                in_array('date', $eval, true)
                 || in_array('datetime', $eval, true)
                 || in_array('time', $eval, true)
                 || in_array('timesec', $eval, true)
@@ -483,7 +488,8 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if (isset($element['TCEforms']['config'])
+        if (
+            isset($element['TCEforms']['config'])
             && empty($element['TCEforms']['config']['renderType'])
         ) {
             if ($element['TCEforms']['config']['type'] === 'input') {
@@ -511,18 +517,21 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if ($element['TCEforms']['config']['type'] === 'input'
+        if (
+            $element['TCEforms']['config']['type'] === 'input'
             || $element['TCEforms']['config']['type'] === 'text'
         ) {
             if (isset($element['TCEforms']['config']['wizards']) && is_array($element['TCEforms']['config']['wizards'])) {
                 foreach ($element['TCEforms']['config']['wizards'] as $wizardName => $wizardConfig) {
-                    if (isset($wizardConfig['type'])
+                    if (
+                        isset($wizardConfig['type'])
                         && $wizardConfig['type'] === 'select'
                         && isset($wizardConfig['items'])
                         && is_array($wizardConfig['items'])
                     ) {
                         $element['TCEforms']['config']['valuePicker']['items'] = $wizardConfig['items'];
-                        if (isset($wizardConfig['mode'])
+                        if (
+                            isset($wizardConfig['mode'])
                             && is_string($wizardConfig['mode'])
                             && in_array($wizardConfig['mode'], ['append', 'prepend', ''])
                         ) {
@@ -548,7 +557,8 @@ class DataStructureV8Controller extends AbstractUpdateController
         $changed = false;
 
         if ($element['TCEforms']['config']['type'] === 'input') {
-            if (isset($element['TCEforms']['config']['wizards'])
+            if (
+                isset($element['TCEforms']['config']['wizards'])
                 && is_array($element['TCEforms']['config']['wizards'])
             ) {
                 foreach ($element['TCEforms']['config']['wizards'] as $wizardName => $wizardConfig) {
@@ -579,14 +589,17 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if ($element['TCEforms']['config']['type'] === 'input'
+        if (
+            $element['TCEforms']['config']['type'] === 'input'
             && !isset($element['TCEforms']['config']['renderType'])
         ) {
-            if (isset($element['TCEforms']['config']['wizards'])
+            if (
+                isset($element['TCEforms']['config']['wizards'])
                 && is_array($element['TCEforms']['config']['wizards'])
             ) {
                 foreach ($element['TCEforms']['config']['wizards'] as $wizardName => $wizardConfig) {
-                    if (isset($wizardConfig['type'])
+                    if (
+                        isset($wizardConfig['type'])
                         && $wizardConfig['type'] === 'popup'
                         && isset($wizardConfig['module']['name'])
                         && $wizardConfig['module']['name'] === 'wizard_link'
@@ -626,14 +639,17 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if ($element['TCEforms']['config']['type'] === 'group'
+        if (
+            $element['TCEforms']['config']['type'] === 'group'
             || $element['TCEforms']['config']['type'] === 'select'
         ) {
-            if (isset($element['TCEforms']['config']['wizards'])
+            if (
+                isset($element['TCEforms']['config']['wizards'])
                 && is_array($element['TCEforms']['config']['wizards'])
             ) {
                 foreach ($element['TCEforms']['config']['wizards'] as $wizardName => $wizardConfig) {
-                    if (isset($wizardConfig['type'])
+                    if (
+                        isset($wizardConfig['type'])
                         && $wizardConfig['type'] === 'popup'
                         && isset($wizardConfig['module']['name'])
                         && $wizardConfig['module']['name'] === 'wizard_edit'
@@ -665,14 +681,17 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if ($element['TCEforms']['config']['type'] === 'group'
+        if (
+            $element['TCEforms']['config']['type'] === 'group'
             || $element['TCEforms']['config']['type'] === 'select'
         ) {
-            if (isset($element['TCEforms']['config']['wizards'])
+            if (
+                isset($element['TCEforms']['config']['wizards'])
                 && is_array($element['TCEforms']['config']['wizards'])
             ) {
                 foreach ($element['TCEforms']['config']['wizards'] as $wizardName => $wizardConfig) {
-                    if (isset($wizardConfig['type'])
+                    if (
+                        isset($wizardConfig['type'])
                         && $wizardConfig['type'] === 'script'
                         && isset($wizardConfig['module']['name'])
                         && $wizardConfig['module']['name'] === 'wizard_add'
@@ -710,14 +729,17 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
 
-        if ($element['TCEforms']['config']['type'] === 'group'
+        if (
+            $element['TCEforms']['config']['type'] === 'group'
             || $element['TCEforms']['config']['type'] === 'select'
         ) {
-            if (isset($element['TCEforms']['config']['wizards'])
+            if (
+                isset($element['TCEforms']['config']['wizards'])
                 && is_array($element['TCEforms']['config']['wizards'])
             ) {
                 foreach ($element['TCEforms']['config']['wizards'] as $wizardName => $wizardConfig) {
-                    if (isset($wizardConfig['type'])
+                    if (
+                        isset($wizardConfig['type'])
                         && $wizardConfig['type'] === 'script'
                         && isset($wizardConfig['module']['name'])
                         && $wizardConfig['module']['name'] === 'wizard_list'
@@ -790,11 +812,13 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
         if ($element['TCEforms']['config']['type'] === 'text') {
-            if (isset($element['TCEforms']['config']['wizards'])
+            if (
+                isset($element['TCEforms']['config']['wizards'])
                 && is_array($element['TCEforms']['config']['wizards'])
             ) {
                 foreach ($element['TCEforms']['config']['wizards'] as $wizardName => $wizardConfig) {
-                    if (isset($wizardConfig['type'])
+                    if (
+                        isset($wizardConfig['type'])
                         && $wizardConfig['type'] === 'script'
                         && isset($wizardConfig['module']['name'])
                         && $wizardConfig['module']['name'] === 'wizard_table'
@@ -830,11 +854,13 @@ class DataStructureV8Controller extends AbstractUpdateController
     {
         $changed = false;
         if ($element['TCEforms']['config']['type'] === 'text') {
-            if (isset($element['TCEforms']['config']['wizards'])
+            if (
+                isset($element['TCEforms']['config']['wizards'])
                 && is_array($element['TCEforms']['config']['wizards'])
             ) {
                 foreach ($element['TCEforms']['config']['wizards'] as $wizardName => $wizardConfig) {
-                    if (isset($wizardConfig['type'])
+                    if (
+                        isset($wizardConfig['type'])
                         && $wizardConfig['type'] === 'script'
                         && isset($wizardConfig['module']['name'])
                         && $wizardConfig['module']['name'] === 'wizard_rte'
@@ -849,7 +875,8 @@ class DataStructureV8Controller extends AbstractUpdateController
                         }
                         unset($element['TCEforms']['config']['wizards'][$wizardName]);
                         $changed = true;
-                    } elseif (isset($wizardConfig['type'])
+                    } elseif (
+                        isset($wizardConfig['type'])
                         && $wizardConfig['type'] === 'script'
                         && isset($wizardConfig['module']['name'])
                         && $wizardConfig['module']['name'] === 'wizard_rte'
@@ -878,7 +905,8 @@ class DataStructureV8Controller extends AbstractUpdateController
     public function migrateSuggestWizardTypeGroup(array &$element): bool
     {
         $changed = false;
-        if ($element['TCEforms']['config']['type'] === 'group'
+        if (
+            $element['TCEforms']['config']['type'] === 'group'
             && isset($element['TCEforms']['config']['internal_type'])
             && $element['TCEforms']['config']['internal_type'] === 'db'
         ) {
@@ -952,7 +980,8 @@ class DataStructureV8Controller extends AbstractUpdateController
     public function migrateSelectShowIconTable(array &$element): bool
     {
         $changed = false;
-        if ($element['TCEforms']['config']['type'] === 'select'
+        if (
+            $element['TCEforms']['config']['type'] === 'select'
             && isset($element['TCEforms']['config']['renderType'])
             && $element['TCEforms']['config']['renderType'] === 'selectSingle'
         ) {
@@ -1049,7 +1078,8 @@ class DataStructureV8Controller extends AbstractUpdateController
 
         if ($element['TCEforms']['config']['type'] === 'inline') {
             if (isset($element['TCEforms']['config']['foreign_types']) && is_array($element['TCEforms']['config']['foreign_types'])) {
-                if (isset($element['TCEforms']['config']['overrideChildTca']['types'])
+                if (
+                    isset($element['TCEforms']['config']['overrideChildTca']['types'])
                     && is_array($element['TCEforms']['config']['overrideChildTca']['types'])
                 ) {
                     $element['TCEforms']['config']['overrideChildTca']['types'] = array_replace_recursive(
@@ -1063,7 +1093,8 @@ class DataStructureV8Controller extends AbstractUpdateController
             }
             if (isset($element['TCEforms']['config']['foreign_selector'], $element['TCEforms']['config']['foreign_selector_fieldTcaOverride']) && is_string($element['TCEforms']['config']['foreign_selector']) && is_array($element['TCEforms']['config']['foreign_selector_fieldTcaOverride'])) {
                 $foreignSelectorFieldName = $element['TCEforms']['config']['foreign_selector'];
-                if (isset($element['TCEforms']['config']['overrideChildTca']['columns'][$foreignSelectorFieldName])
+                if (
+                    isset($element['TCEforms']['config']['overrideChildTca']['columns'][$foreignSelectorFieldName])
                     && is_array($element['TCEforms']['config']['overrideChildTca']['columns'][$foreignSelectorFieldName])
                 ) {
                     $element['TCEforms']['config']['overrideChildTca']['columns'][$foreignSelectorFieldName] = array_replace_recursive(
@@ -1096,7 +1127,8 @@ class DataStructureV8Controller extends AbstractUpdateController
         $changed = false;
 
         // If no wizard is left after migration, unset the whole sub array
-        if (isset($element['TCEforms']['config']['wizards'])
+        if (
+            isset($element['TCEforms']['config']['wizards'])
             && empty($element['TCEforms']['config']['wizards'])
         ) {
             unset($element['TCEforms']['config']['wizards']);

--- a/Classes/Controller/Backend/PageLayoutController.php
+++ b/Classes/Controller/Backend/PageLayoutController.php
@@ -147,7 +147,7 @@ class PageLayoutController extends ActionController
         $this->setPageInfo();
 
         /** @TODO better handle this with an configuration object */
-        $this->settings['configuration'] =  [
+        $this->settings['configuration'] = [
             'allAvailableLanguages' => $this->allAvailableLanguages,
             // If we have more then "all-languages" and 1 editors language available
             'moreThenOneLanguageAvailable' => count($this->allAvailableLanguages) > 2 ? true : false,

--- a/Classes/Domain/Model/Configuration/TemplateConfiguration.php
+++ b/Classes/Domain/Model/Configuration/TemplateConfiguration.php
@@ -97,7 +97,7 @@ class TemplateConfiguration extends AbstractConfiguration
         return $this->mapping;
     }
 
-    public function setMapping(array $mapping):void
+    public function setMapping(array $mapping): void
     {
         $this->mapping = $mapping;
     }

--- a/Classes/Service/ApiService.php
+++ b/Classes/Service/ApiService.php
@@ -764,7 +764,7 @@ class ApiService
                 'uid' => $locationArr[1],
                 'sheet' => $locationArr[2],
                 'sLang' => $locationArr[3],
-                'field' => substr($locationArr[4], 1), // Remove first "#" char
+                'field' => substr($locationArr[4], 1), /* Remove first "#" char */
                 'vLang' => $locationArr[5],
                 'position' => $locationArr[6],
                 'targetCheckUid' => $targetCheckArr[1],
@@ -797,7 +797,7 @@ class ApiService
                 . ':' . $flexformPointer['uid']
                 . ':' . $flexformPointer['sheet']
                 . ':' . $flexformPointer['sLang']
-                . ':#' . $flexformPointer['field'] // Add "#" on first
+                . ':#' . $flexformPointer['field'] /* Add "#" on first */
                 . ':' . $flexformPointer['vLang']
                 . ':' . $flexformPointer['position'];
             if (isset($flexformPointer['targetCheckUid'])) {

--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -280,7 +280,7 @@ class ProcessingService
                             $childs[$fieldKey][$vKey] = [];
                         }
                     }
-            }
+                }
             }
             /** @TODO What does this do?
             elseif ($fieldConfig['type'] !== 'array' && $fieldConfig['TCEforms']['config']) {
@@ -637,7 +637,7 @@ class ProcessingService
                 'uid' => $locationArr[1],
                 'sheet' => $locationArr[2],
                 'sLang' => $locationArr[3],
-                'field' => substr($locationArr[4], 1), // Remove first "#" char
+                'field' => substr($locationArr[4], 1), /* Remove first "#" char */
                 'vLang' => $locationArr[5],
                 'position' => (int)$locationArr[6],
             ];

--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -146,7 +146,7 @@ class ProcessingService
             try {
                 $mappingConfiguration = ApiHelperUtility::getMappingConfiguration($row['tx_templavoilaplus_map']);
             } catch (ConfigurationException | MissingPlacesException | InvalidIdentifierException | \TypeError $e) {
-                // Empty is correct
+                $mappingConfiguration = null;
             }
         }
         return $mappingConfiguration;

--- a/Resources/Public/StyleSheet/PageLayout.css
+++ b/Resources/Public/StyleSheet/PageLayout.css
@@ -102,7 +102,7 @@ nav.flashRed {
 }
 
 .module-body > .callout {
-    margin-top: 0px;
+    margin-top: 0;
     margin-right: 75px;
 }
 
@@ -384,8 +384,9 @@ nav.flashRed {
 }
 
 .dark-mode-on .bg-light {
-    background-color: rgba(128,128,128,var(--bs-bg-opacity)) !important;
+    background-color: rgba(128, 128, 128, var(--bs-bg-opacity)) !important;
 }
+
 .dark-mode-on .nav-tabs,
 .dark-mode-on .panel .panel-heading {
     background-color: #808080;
@@ -395,12 +396,12 @@ nav.flashRed {
 .dark-mode-on .nav-tabs > li > a.nav-link.active,
 .dark-mode-on .nav.nav-tabs > li:not(.nav-item) > a.active:not(.nav-link) {
     background-color: #393939;
-    color: #DDD;
+    color: #ddd;
     border-bottom-color: #393939;
 }
 
 .dark-mode-on .bg-info {
-  background-color: rgba(35, 40, 90, var(--bs-bg-opacity)) !important;
+    background-color: rgba(35, 40, 90, var(--bs-bg-opacity)) !important;
 }
 
 /** Tooltipster own dark mode */

--- a/Tests/Unit/Utility/ApiHelperUtilityTest.php
+++ b/Tests/Unit/Utility/ApiHelperUtilityTest.php
@@ -2,13 +2,18 @@
 
 namespace Tvp\TemplaVoilaPlus\Tests\Utility;
 
+use Prophecy\PhpUnit\ProphecyTrait;
 use Tvp\TemplaVoilaPlus\Exception\InvalidIdentifierException;
 use Tvp\TemplaVoilaPlus\Exception\MissingPlacesException;
 use Tvp\TemplaVoilaPlus\Utility\ApiHelperUtility;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 class ApiHelperUtilityTest extends UnitTestCase
 {
+    use ProphecyTrait;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -31,6 +36,12 @@ class ApiHelperUtilityTest extends UnitTestCase
      */
     public function getMappingConfigurationFailsWithUnknownPlaceInIdentifier()
     {
+        $extensionManagerProphecy = $this->prophesize(ExtensionConfiguration::class);
+        $extensionManagerProphecy->get('templavoilaplus')->shouldBeCalled()->willReturn(
+            [
+            ]
+        );
+        GeneralUtility::addInstance(ExtensionConfiguration::class, $extensionManagerProphecy->reveal());
         $this->expectException(MissingPlacesException::class);
         $result = ApiHelperUtility::getMappingConfiguration('thisDoesntExist:thisDoesntExistEither');
     }

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 		"jangregor/phpstan-prophecy": "^1.0.0",
 		"jpmschuler/tvplus_test_theme": "*@dev",
 		"php-coveralls/php-coveralls": "^2.5.2",
+		"phpspec/prophecy-phpunit": "^2.0",
 		"phpstan/extension-installer": "^1.1.0",
 		"phpstan/phpstan": "^1.6.2",
 		"phpstan/phpstan-phpunit": "^1.1.1",

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
 			"@ci:php:copypaste:baseline",
 			"@ci:php:copypaste:ignored"
 		],
-		"ci:php:copypaste:baseline": "@php ./tools/phpcpd --exclude Classes/Form --exclude Classes/Updates --exclude Classes/Controller/Backend/ControlCenter/MappingsController.php --exclude Classes/Utility/TemplaVoilaUtility.php Classes",
+		"ci:php:copypaste:baseline": "@php ./tools/phpcpd --exclude Classes/Form --exclude Classes/Updates --exclude Classes/Controller/Backend/ControlCenter/MappingsController.php --exclude Classes/Utility/TemplaVoilaUtility.php --exclude Classes/Service/ApiService.php Classes",
 		"ci:php:copypaste:ignored": "@php ./tools/phpcpd --exclude Classes/Form --exclude Classes/Updates Classes || true",
 		"ci:php:cs-fixer": "php-cs-fixer fix --config .php-cs-fixer.php -v --dry-run --using-cache no --diff",
 		"ci:php:lint": "@ci:php:lint:local",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,6 +66,31 @@ parameters:
 			path: Classes/Controller/Backend/Ajax/ExtendedNewContentElementController.php
 
 		-
+			message: "#^Undefined variable\\: \\$countStatic$#"
+			count: 1
+			path: Classes/Controller/Backend/ControlCenter/Update/DataStructureV10Controller.php
+
+		-
+			message: "#^Undefined variable\\: \\$countStatic$#"
+			count: 1
+			path: Classes/Controller/Backend/ControlCenter/Update/DataStructureV11Controller.php
+
+		-
+			message: "#^Undefined variable\\: \\$countStatic$#"
+			count: 1
+			path: Classes/Controller/Backend/ControlCenter/Update/DataStructureV8Controller.php
+
+		-
+			message: "#^Class Tvp\\\\TemplaVoilaPlus\\\\Controller\\\\Backend\\\\ControlCenter\\\\Update\\\\UnquotedString not found\\.$#"
+			count: 1
+			path: Classes/Controller/Backend/ControlCenter/Update/TemplaVoilaPlus8Controller.php
+
+		-
+			message: "#^Instantiated class Tvp\\\\TemplaVoilaPlus\\\\Controller\\\\Backend\\\\ControlCenter\\\\Update\\\\UnquotedString not found\\.$#"
+			count: 13
+			path: Classes/Controller/Backend/ControlCenter/Update/TemplaVoilaPlus8Controller.php
+
+		-
 			message: "#^Call to an undefined method Tvp\\\\TemplaVoilaPlus\\\\Controller\\\\Backend\\\\Handler\\\\DoktypeLinkHandler\\:\\:getLinkButton\\(\\)\\.$#"
 			count: 1
 			path: Classes/Controller/Backend/Handler/DoktypeLinkHandler.php
@@ -147,7 +172,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\GeneralUtility\\:\\:devLog\\(\\)\\.$#"
-			count: 28
+			count: 26
 			path: Classes/Service/ApiService.php
 
 		-
@@ -161,14 +186,34 @@ parameters:
 			path: Classes/Service/DataHandling/DataHandler.php
 
 		-
+			message: "#^Access to an undefined property Tvp\\\\TemplaVoilaPlus\\\\Service\\\\ProcessingService\\:\\:\\$debug\\.$#"
+			count: 8
+			path: Classes/Service/ProcessingService.php
+
+		-
+			message: "#^Access to an undefined property Tvp\\\\TemplaVoilaPlus\\\\Service\\\\ProcessingService\\:\\:\\$modifyReferencesInLiveWS\\.$#"
+			count: 1
+			path: Classes/Service/ProcessingService.php
+
+		-
 			message: "#^Access to an undefined property Tvp\\\\TemplaVoilaPlus\\\\Service\\\\ProcessingService\\:\\:\\$rootTable\\.$#"
 			count: 1
+			path: Classes/Service/ProcessingService.php
+
+		-
+			message: "#^Call to an undefined static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\GeneralUtility\\:\\:devLog\\(\\)\\.$#"
+			count: 8
 			path: Classes/Service/ProcessingService.php
 
 		-
 			message: "#^Undefined variable\\: \\$tt_content_elementRegister$#"
 			count: 1
 			path: Classes/Service/ProcessingService.php
+
+		-
+			message: "#^Access to an undefined property Tvp\\\\TemplaVoilaPlus\\\\Updates\\\\Typo3Lts9Update\\:\\:\\$extConf\\.$#"
+			count: 1
+			path: Classes/Updates/Typo3Lts9Update.php
 
 		-
 			message: "#^Class TYPO3\\\\CMS\\\\Lang\\\\LanguageService not found\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -66,11 +66,6 @@ parameters:
 			path: Classes/Controller/Backend/Ajax/ExtendedNewContentElementController.php
 
 		-
-			message: "#^Method Tvp\\\\TemplaVoilaPlus\\\\Controller\\\\Backend\\\\ControlCenter\\\\AbstractUpdateController\\:\\:assignDefault\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: Classes/Controller/Backend/ControlCenter/AbstractUpdateController.php
-
-		-
 			message: "#^Call to an undefined method Tvp\\\\TemplaVoilaPlus\\\\Controller\\\\Backend\\\\Handler\\\\DoktypeLinkHandler\\:\\:getLinkButton\\(\\)\\.$#"
 			count: 1
 			path: Classes/Controller/Backend/Handler/DoktypeLinkHandler.php


### PR DESCRIPTION
Normal roundup. 

After another readup I found there is an option to have post-statement comments, but only if they are inline comments `/* */`, that allows the current behaviour - however single-line-comments `//` are forbidden after a statement.