### PR TITLE
Backend preview nodes improvement

### DIFF
--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TypeInformation.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TypeInformation.html
@@ -9,9 +9,12 @@
 
 
 <f:comment>Get title from TCA typeColumn</f:comment>
-<f:if condition="{settings.configuration.TCA.{node.raw.table}.ctrl.typeicon_column}">
-    <f:variable name="typeColumn" value="{settings.configuration.TCA.{node.raw.table}.ctrl.typeicon_column}"/>
+<f:if condition="{settings.configuration.TCA.{node.raw.table}.ctrl.type}">
+    <f:variable name="typeColumn" value="{settings.configuration.TCA.{node.raw.table}.ctrl.type}"/>
+    <f:variable name="type" value="{node.raw.entity.{typeColumn}}"/>
     <f:variable name="title" value="{tvp:backend.labelFromItemlist(table:'{node.raw.table}', fieldName:'{typeColumn}', key:'{node.raw.entity.{typeColumn}}')}"/>
+    <f:variable name="iconList" value="{settings.configuration.TCA.{node.raw.table}.ctrl.typeicon_classes}"/>
+    <f:variable name="typeIcon" value="{iconList.{type}}"/>
 </f:if>
 
 
@@ -22,6 +25,7 @@
 
 <f:if condition="{title}">
     <strong>
+        <f:if condition="{typeIcon}"><core:icon identifier="{typeIcon}" size="small" /></f:if>
             <f:translate key="{title}" default="{title}"/>
     </strong><br/>
 </f:if>

--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TypeInformation.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TypeInformation.html
@@ -9,12 +9,9 @@
 
 
 <f:comment>Get title from TCA typeColumn</f:comment>
-<f:if condition="{settings.configuration.TCA.{node.raw.table}.ctrl.type}">
-    <f:variable name="typeColumn" value="{settings.configuration.TCA.{node.raw.table}.ctrl.type}"/>
-    <f:variable name="type" value="{node.raw.entity.{typeColumn}}"/>
+<f:if condition="{settings.configuration.TCA.{node.raw.table}.ctrl.typeicon_column}">
+    <f:variable name="typeColumn" value="{settings.configuration.TCA.{node.raw.table}.ctrl.typeicon_column}"/>
     <f:variable name="title" value="{tvp:backend.labelFromItemlist(table:'{node.raw.table}', fieldName:'{typeColumn}', key:'{node.raw.entity.{typeColumn}}')}"/>
-    <f:variable name="iconList" value="{settings.configuration.TCA.{node.raw.table}.ctrl.typeicon_classes}"/>
-    <f:variable name="typeIcon" value="{iconList.{type}}"/>
 </f:if>
 
 
@@ -25,7 +22,6 @@
 
 <f:if condition="{title}">
     <strong>
-        <f:if condition="{typeIcon}"><core:icon identifier="{typeIcon}" size="small" /></f:if>
             <f:translate key="{title}" default="{title}"/>
     </strong><br/>
 </f:if>

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Bullets.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Bullets.html
@@ -1,9 +1,7 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
-<f:if condition="{node.raw.entity.subheader}">
-    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'subheader')}" />
-    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>: {node.raw.entity.subheader}<br />
-</f:if>
+<f:render partial="Backend/Preview/Tt_content/Elements/Header" arguments="{node: node}" />
+<f:render partial="Backend/Preview/Tt_content/Elements/SubHeader" arguments="{node: node}" />
 
 <f:if condition="{node.raw.entity.bodytext}">
     <f:variable name="entries" value="{tvp:splitIntoArray(value:'{node.raw.entity.bodytext}', pattern:'\R', limit: 10)}" />

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Elements/Header.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Elements/Header.html
@@ -1,0 +1,13 @@
+{namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
+
+<f:if condition="{node.raw.entity.header} && {node.raw.entity.header_layout} !== 100">
+    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'header')}" />
+    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>:
+
+    <f:format.crop maxCharacters="2000">
+        <tvp:format.wordLength maxCharacters="75">
+            <tvp:format.stripTags whitespace="true">{node.raw.entity.header}</tvp:format.stripTags>
+        </tvp:format.wordLength>
+    </f:format.crop>
+    <br />
+</f:if>

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Elements/SubHeader.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Elements/SubHeader.html
@@ -1,0 +1,6 @@
+{namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
+
+<f:if condition="{node.raw.entity.subheader}">
+    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'subheader')}" />
+    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>: {node.raw.entity.subheader}<br />
+</f:if>

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Header.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Header.html
@@ -1,18 +1,4 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
-<f:if condition="{node.raw.entity.header}">
-    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'header')}" />
-    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>:
-
-    <f:format.crop maxCharacters="2000">
-        <tvp:format.wordLength maxCharacters="75">
-            <tvp:format.stripTags whitespace="true">{node.raw.entity.header}</tvp:format.stripTags>
-        </tvp:format.wordLength>
-    </f:format.crop>
-    <br />
-</f:if>
-
-<f:if condition="{node.raw.entity.subheader}">
-    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'subheader')}" />
-    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>: {node.raw.entity.subheader}<br />
-</f:if>
+<f:render partial="Backend/Preview/Tt_content/Elements/Header" arguments="{node: node}" />
+<f:render partial="Backend/Preview/Tt_content/Elements/SubHeader" arguments="{node: node}" />

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Html.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Html.html
@@ -1,10 +1,8 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
-<f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'bodytext')}" />
-<strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>
 <f:format.crop maxCharacters="2000">
     <tvp:format.wordLength maxCharacters="75">
-        {node.raw.entity.bodytext}
+        <f:format.htmlentities>{node.raw.entity.bodytext}</f:format.htmlentities>
     </tvp:format.wordLength>
 </f:format.crop>
 

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Image.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Image.html
@@ -1,8 +1,6 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
-<f:if condition="{node.raw.entity.subheader}">
-    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'subheader')}" />
-    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>: {node.raw.entity.subheader}<br />
-</f:if>
+<f:render partial="Backend/Preview/Tt_content/Elements/Header" arguments="{node: node}" />
+<f:render partial="Backend/Preview/Tt_content/Elements/SubHeader" arguments="{node: node}" />
 
 <tvp:backend.thumbCode row="{node.raw.entity}" table="tt_content" fieldName="image" />

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Shortcut.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Shortcut.html
@@ -1,0 +1,7 @@
+{namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
+<f:if condition="{node.raw.entity.records}">
+    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'records')}"/>
+    <strong>
+        <f:translate key="{itemLabel}" default="{itemLabel}"/>
+    </strong>{node.raw.entity.records}<br/>
+</f:if>

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Text.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Text.html
@@ -1,12 +1,7 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
-<f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'bodytext')}" />
-<strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong><br />
-
-<f:if condition="{node.raw.entity.subheader}">
-    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'subheader')}" />
-    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>: {node.raw.entity.subheader}<br />
-</f:if>
+<f:render partial="Backend/Preview/Tt_content/Elements/Header" arguments="{node: node}" />
+<f:render partial="Backend/Preview/Tt_content/Elements/SubHeader" arguments="{node: node}" />
 
 <f:if condition="{node.raw.entity.bodytext}">
     <f:format.crop maxCharacters="2000">

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Textmedia.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Textmedia.html
@@ -1,9 +1,7 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
-<f:if condition="{node.raw.entity.subheader}">
-    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'subheader')}" />
-    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>: {node.raw.entity.subheader}<br />
-</f:if>
+<f:render partial="Backend/Preview/Tt_content/Elements/Header" arguments="{node: node}" />
+<f:render partial="Backend/Preview/Tt_content/Elements/SubHeader" arguments="{node: node}" />
 
 <f:if condition="{node.raw.entity.bodytext}">
     <f:format.crop maxCharacters="2000">

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Textpic.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Textpic.html
@@ -1,9 +1,7 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
-<f:if condition="{node.raw.entity.subheader}">
-    <f:variable name="itemLabel" value="{tvp:backend.itemLabel(table:'tt_content', fieldName:'subheader')}" />
-    <strong><f:translate key="{itemLabel}" default="{itemLabel}" /></strong>: {node.raw.entity.subheader}<br />
-</f:if>
+<f:render partial="Backend/Preview/Tt_content/Elements/Header" arguments="{node: node}" />
+<f:render partial="Backend/Preview/Tt_content/Elements/SubHeader" arguments="{node: node}" />
 
 <f:if condition="{node.raw.entity.bodytext}">
     <f:format.crop maxCharacters="2000">


### PR DESCRIPTION
The currently used backend preview nodes could be slightly improvement, as my test system uses a lot of different kinds in combination which showed that stuff is a bit different, thus I propose:

- add shortcut tt_content preview, currently just showing the `table_uid` list
- always output header and subhead of tt_content (except for shortcut, html of course), thus put in their own partial. Header should respect header_layout=100 as hidden thus not showing it.
- ~the type is the first element in the preview, it should have the icon as a prefix to differentiate from field labels, else we would have, e.g.~
- the html tt_content preview should not show the interpreted HTML, but rather HTML code to prevent XSS and other shenanigans 