### PR TITLE
[TASK] node titlebar should crop title via CSS and shouldn't wrap

### DIFF
--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TitleBar.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TitleBar.html
@@ -1,13 +1,12 @@
 <nav class="navbar navbar-expand-lg {f:if(condition: '{settings.configuration.is11orNewer}', then:'', else: 'navbar-default')} navbar-light bg-light sortable_handle">
-    <div class="container-fluid">
-        <f:render partial="Backend/Handler/DoktypeDefaultHandler/Node/TitleBarLeftButtons" arguments="{node: node}" />
-        <ul class="{f:if(condition: '{settings.configuration.is11orNewer}', then:'', else: 'nav')} navbar-nav me-auto">
-            <li class="navbar-brand ms-2">
-                <f:if condition="!{node.rendering.belongsToCurrentPage}"><em></f:if>
-                <f:format.crop maxCharacters="20" respectWordBoundaries="false">{node.rendering.fullTitle}</f:format.crop>
-                <f:if condition="!{node.rendering.belongsToCurrentPage}"></em></f:if>
-            </li>
-        </ul>
-        <f:render partial="Backend/Handler/DoktypeDefaultHandler/Node/TitleBarRightButtons" arguments="{node: node}" />
+    <div class="container-fluid tvp-node-header">
+        <f:render partial="Backend/Handler/DoktypeDefaultHandler/Node/TitleBarLeftButtons" arguments="{node: node}"/>
+        <div class="me-auto ms-2 tvp-node-title">
+            <f:if condition="!{node.rendering.belongsToCurrentPage}"><em></f:if>
+            {node.rendering.fullTitle}
+            <f:if condition="!{node.rendering.belongsToCurrentPage}"></em></f:if>
+        </div>
+        <f:render partial="Backend/Handler/DoktypeDefaultHandler/Node/TitleBarRightButtons" arguments="{node: node}"/>
     </div>
 </nav>
+

--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TitleBarLeftButtons.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TitleBarLeftButtons.html
@@ -1,4 +1,4 @@
-<div class="{f:if(condition: '{settings.configuration.is11orNewer}', then:'', else: 'navbar-brand')} t3-page-ce-header-icons-left">
+<div class="{f:if(condition: '{settings.configuration.is11orNewer}', then:'', else: 'navbar-brand')} t3-page-ce-header-icons-left tvp-node-header-icons-left">
     <span title="{settings.configuration.allAvailableLanguages.{node.raw.entity.sys_language_uid}.title}">
         <core:icon identifier="{settings.configuration.allAvailableLanguages.{node.raw.entity.sys_language_uid}.flagIcon}" />
     </span>

--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TitleBarRightButtons.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TitleBarRightButtons.html
@@ -1,4 +1,4 @@
-<div class="{f:if(condition: '{settings.configuration.is11orNewer}', then:'', else: 'navbar-brand navbar-right')} btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
+<div class="{f:if(condition: '{settings.configuration.is11orNewer}', then:'', else: 'navbar-brand navbar-right')} btn-toolbar tvp-node-header-icons-right" role="toolbar" aria-label="Toolbar with button groups">
     <div class="btn-group" role="group" aria-label="First group">
         <button type="button" class="btn btn-default btn-sm tvp-record-switch-visibility">
             <f:if condition="{node.raw.entity.hidden}">

--- a/Resources/Public/StyleSheet/PageLayout.css
+++ b/Resources/Public/StyleSheet/PageLayout.css
@@ -174,6 +174,29 @@ nav.flashRed {
     margin-bottom: 0;
 }
 
+.tvp-node {
+    max-width: 100%;
+}
+
+.tvp-node-header {
+    flex-wrap: nowrap !important;
+}
+
+.tvp-node-header-icons-left,
+.tvp-node-header-icons-right {
+    white-space: nowrap;
+    flex-wrap: nowrap;
+}
+
+.tvp-node-title {
+    font-size: .9375rem;
+    white-space: nowrap;
+    overflow: hidden;
+    padding-bottom: 4px;
+    padding-top: 4px;
+    text-overflow: ellipsis;
+}
+
 /** @TODO default transition only while switching theme? */
 .animationTransition {
     transition: all 0.5s linear 0s;


### PR DESCRIPTION
Currently the title was hard-cropped at 20chars; however CSS allows for soft-cropping. This would even allow to mouse-over for full title.

![space](https://user-images.githubusercontent.com/12411176/180583895-2dd422eb-c3ca-4288-8ab8-fd4ea8394ad1.png)
![small](https://user-images.githubusercontent.com/12411176/180583893-e428adf9-20c9-4b3e-93c2-e356c1033164.png)
