### PR TITLE
New ContentElement Wizard improvements

### DIFF
--- a/Resources/Private/Language/Backend/PageLayout.xlf
+++ b/Resources/Private/Language/Backend/PageLayout.xlf
@@ -118,12 +118,9 @@
                 <source>Error: This FCE has no mapping set.</source>
             </trans-unit>
 
-			<trans-unit id="newCeWizardTitle" xml:space="preserve">
-				<source>Add new content to page.</source>
-			</trans-unit>
-
+			<!-- newContentElementWizard -->
 			<trans-unit id="newCeWizardDesc" xml:space="preserve">
-				<source>Please select the content type you want to add from the appropiate tab and drag and drop it to the desired position.</source>
+				<source>Please select the content type you want to add from the appropiate tab and drag and drop its icon to the desired position.</source>
 			</trans-unit>
 
         </body>

--- a/Resources/Private/Language/Backend/PageLayout.xlf
+++ b/Resources/Private/Language/Backend/PageLayout.xlf
@@ -118,6 +118,13 @@
                 <source>Error: This FCE has no mapping set.</source>
             </trans-unit>
 
+			<trans-unit id="newCeWizardTitle" xml:space="preserve">
+				<source>Add new content to page.</source>
+			</trans-unit>
+
+			<trans-unit id="newCeWizardDesc" xml:space="preserve">
+				<source>Please select the content type you want to add from the appropiate tab and drag and drop it to the desired position.</source>
+			</trans-unit>
 
         </body>
     </file>

--- a/Resources/Private/Templates/Backend/Ajax/ContentElements.html
+++ b/Resources/Private/Templates/Backend/Ajax/ContentElements.html
@@ -1,7 +1,7 @@
 {namespace core = TYPO3\CMS\Core\ViewHelpers}
 <div>
-    <h1><f:translate key="newCeWizardTitle"/></h1>
-    <p><f:translate key="newCeWizardDesc"/></p>
+    <h2><f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_misc.xlf:createNewContent" /></h2>
+    <p><f:translate key="LLL:EXT:templavoilaplus/Resources/Private/Language/Backend/PageLayout.xlf:newCeWizardDesc" /></p>
     <nav>
         <ul class="nav nav-tabs t3js-tabs" id="nav-tab" role="tablist">
             <f:for each="{contentElementsConfig}" as="section" key="sectionKey" iteration="iter">

--- a/Resources/Private/Templates/Backend/Ajax/ContentElements.html
+++ b/Resources/Private/Templates/Backend/Ajax/ContentElements.html
@@ -2,16 +2,16 @@
 <div>
     <nav>
         <ul class="nav nav-tabs t3js-tabs" id="nav-tab" role="tablist">
-            <f:for each="{contentElementsConfig}" as="section" key="sectionKey">
+            <f:for each="{contentElementsConfig}" as="section" key="sectionKey" iteration="iter">
                 <li role="presentation" class="t3js-tabmenu-item">
-                    <a class="nav-link" id="nav-{sectionKey}-tab" data-toggle="tab" data-bs-toggle="tab" href="#nav-{sectionKey}" role="tab" aria-controls="nav-{sectionKey}" aria-selected="false">{section.label}</a>
+                    <a class="nav-link {f:if(condition:iter.isFirst, then: ' active')}" id="nav-{sectionKey}-tab" data-toggle="tab" data-bs-toggle="tab" href="#nav-{sectionKey}" role="tab" aria-controls="nav-{sectionKey}" aria-selected="{f:if(condition:iter.isFirst, then: 'true', else: 'false')}">{section.label}</a>
                 </li>
             </f:for>
         </ul>
     </nav>
     <div class="tab-content" id="nav-tabContent">
-        <f:for each="{contentElementsConfig}" as="section" key="sectionKey">
-            <div class="tab-pane tvjs-drag" id="nav-{sectionKey}" role="tabpanel" aria-labelledby="nav-{sectionKey}-tab">
+        <f:for each="{contentElementsConfig}" as="section" key="sectionKey" iteration="iter">
+            <div class="tab-pane tvjs-drag {f:if(condition:iter.isFirst, then: ' active show')}" id="nav-{sectionKey}" role="tabpanel" aria-labelledby="nav-{sectionKey}-tab">
                 <f:for each="{section.contentElements}" as="contentElement" key="contentElementKey">
                     <div class="{f:if(condition: '{settings.configuration.is11orNewer}', then: '', else: 'media  media-new-content-element-wizard')} d-flex align-items-start p-2" data-record-table="tt_content" data-panel="newcontent" data-element-row="{contentElement.element-row -> f:format.json()}">
                         <div class="{f:if(condition: '{settings.configuration.is11orNewer}', then:'', else: 'media-left')} flex-shrink-0 dragHandle"><core:icon identifier="{contentElement.iconIdentifier}" size="default" /></div>

--- a/Resources/Private/Templates/Backend/Ajax/ContentElements.html
+++ b/Resources/Private/Templates/Backend/Ajax/ContentElements.html
@@ -1,5 +1,7 @@
 {namespace core = TYPO3\CMS\Core\ViewHelpers}
 <div>
+    <h1><f:translate key="newCeWizardTitle"/></h1>
+    <p><f:translate key="newCeWizardDesc"/></p>
     <nav>
         <ul class="nav nav-tabs t3js-tabs" id="nav-tab" role="tablist">
             <f:for each="{contentElementsConfig}" as="section" key="sectionKey" iteration="iter">

--- a/Resources/Public/StyleSheet/PageLayout.css
+++ b/Resources/Public/StyleSheet/PageLayout.css
@@ -253,6 +253,10 @@ nav.flashRed {
     max-height: none;
 }
 
+.tooltipster-sidetip .tooltipster-content h2 {
+    margin-top: .5em;
+}
+
 .tooltipster-sidetip .tooltipster-box {
     overflow: hidden;
 }


### PR DESCRIPTION
The new ContentElement Wizard  currently has low UX discoverability. In order to improve the transition for editors it should be made clearer how it works.

So this proposes two changes:
a) The first tab (in most cases probably standard content elements) should be active initially
b) There should be a heading "add new content element" as well as a description, that one needs to use drag and drop instead of click as previously