### PR TITLE
Page module: remove redundant labels

### DIFF
--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/ChildsBeLayouts.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/ChildsBeLayouts.html
@@ -4,7 +4,7 @@
     <f:for each="{fieldConfig}" key="fieldKey" as="subFieldConfig">
         <f:if condition="!{childElements.{fieldKey}}">
             <f:then>
-            </f:then>>
+            </f:then>
         </f:if>
     </f:for>
 </f:section>

--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TypeInformation.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node/TypeInformation.html
@@ -20,7 +20,8 @@
     <f:variable name="title" value="{tvp:backend.labelFromMappingConfiguration(identifier:'{node.raw.entity.tx_templavoilaplus_map}')}"/>
 </f:if>
 
-<f:if condition="{title}">
+<f:comment>Don't show pages typeColumn as only type=standard pages are shown here anyways</f:comment>
+<f:if condition="{title} && {node.raw.table} != 'pages'">
     <strong>
             <f:translate key="{title}" default="{title}"/>
     </strong><br/>

--- a/Resources/Private/Partials/Backend/Preview/Tt_content/Default.html
+++ b/Resources/Private/Partials/Backend/Preview/Tt_content/Default.html
@@ -1,7 +1,7 @@
 {namespace tvp=Tvp\TemplaVoilaPlus\ViewHelpers}
 
 <f:for each="{node.datastructure.sheets.sDEF.ROOT.el}" key="fieldName" as="fieldConfig">
-    <f:if condition="!{node.childNodes.sDEF.lDEF.{fieldName}.vDEF}">
+    <f:if condition="!{node.childNodes.sDEF.lDEF.{fieldName}.vDEF} && {node.flexform.data.sDEF.lDEF.{fieldName}.vDEF}">
         <f:if condition="{fieldConfig.TCEforms.label}">
             <strong><f:translate key="{fieldConfig.TCEforms.label}" default="{fieldConfig.TCEforms.label}" /></strong>
         </f:if>


### PR DESCRIPTION
The page module has two redundant labels:

1. On the top each node has a label of its type. For pages this is "Standard" as all other page types (e.g. Shortcut, Sysfolder) don't use a node view, thus this label can be removed.
2. On the bottom of each node there is a flex form fields preview. for pages with page areas, this just shows nothing, just the headings. As this at least for page areas is redundant and not helpful, it will now just conditionally output if there is something to display.