### PR TITLE
[REGRESSION] activate first cewizard tab in pre-11LTS 

### DIFF
--- a/Resources/Private/Templates/Backend/Ajax/ContentElements.html
+++ b/Resources/Private/Templates/Backend/Ajax/ContentElements.html
@@ -5,15 +5,17 @@
     <nav>
         <ul class="nav nav-tabs t3js-tabs" id="nav-tab" role="tablist">
             <f:for each="{contentElementsConfig}" as="section" key="sectionKey" iteration="iter">
-                <li role="presentation" class="t3js-tabmenu-item">
-                    <a class="nav-link {f:if(condition:iter.isFirst, then: ' active')}" id="nav-{sectionKey}-tab" data-toggle="tab" data-bs-toggle="tab" href="#nav-{sectionKey}" role="tab" aria-controls="nav-{sectionKey}" aria-selected="{f:if(condition:iter.isFirst, then: 'true', else: 'false')}">{section.label}</a>
+                <li role="presentation" class="t3js-tabmenu-item {f:if(condition:'{iter.isFirst} && !{settings.configuration.is11orNewer}', then: ' active')}">
+                    <a class="nav-link {f:if(condition:'{iter.isFirst} && {settings.configuration.is11orNewer}', then: ' active')}" id="nav-{sectionKey}-tab" data-toggle="tab" data-bs-toggle="tab" href="#nav-{sectionKey}" role="tab"
+                       aria-controls="nav-{sectionKey}" aria-selected="{f:if(condition:iter.isFirst, then: 'true', else: 'false')}"
+                       {f:if(condition:'{iter.isFirst} && !{settings.configuration.is11orNewer}', then: ' aria-expanded="true"')}>{section.label}</a>
                 </li>
             </f:for>
         </ul>
     </nav>
     <div class="tab-content" id="nav-tabContent">
         <f:for each="{contentElementsConfig}" as="section" key="sectionKey" iteration="iter">
-            <div class="tab-pane tvjs-drag {f:if(condition:iter.isFirst, then: ' active show')}" id="nav-{sectionKey}" role="tabpanel" aria-labelledby="nav-{sectionKey}-tab">
+            <div class="tab-pane tvjs-drag {f:if(condition:iter.isFirst, then: ' active')} {f:if(condition:'{iter.isFirst} && {settings.configuration.is11orNewer}', then: ' show')}" id="nav-{sectionKey}" role="tabpanel" aria-labelledby="nav-{sectionKey}-tab">
                 <f:for each="{section.contentElements}" as="contentElement" key="contentElementKey">
                     <div class="{f:if(condition: '{settings.configuration.is11orNewer}', then: '', else: 'media  media-new-content-element-wizard')} d-flex align-items-start p-2" data-record-table="tt_content" data-panel="newcontent" data-element-row="{contentElement.element-row -> f:format.json()}">
                         <div class="{f:if(condition: '{settings.configuration.is11orNewer}', then:'', else: 'media-left')} flex-shrink-0 dragHandle"><core:icon identifier="{contentElement.iconIdentifier}" size="default" /></div>


### PR DESCRIPTION
cewizard uses different tab active items as 11LTS thus some new IFs are in place to put the `active` class at the right spot