### PR TITLE
[BUGFIX] fetchRecordLocalizations needs transOrigPointerField

### DIFF
--- a/Classes/Domain/Repository/Localization/LocalizationRepository.php
+++ b/Classes/Domain/Repository/Localization/LocalizationRepository.php
@@ -52,7 +52,7 @@ class LocalizationRepository
                 ->from($table)
                 ->where(
                     $queryBuilder->expr()->eq(
-                        $tcaCtrl['origUid'],
+                        $tcaCtrl['transOrigPointerField'],
                         // $tcaCtrl['translationSource'] ?? $tcaCtrl['transOrigPointerField'] Thats from core, but wrong!
                         $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT)
                     ),


### PR DESCRIPTION
`LocalizationRepository::fetchRecordLocalizations()` gets the Localizations for the nodes. However the SQL used for that refers currently to  [origUid](https://docs.typo3.org/m/typo3/reference-tca/main/en-us/singlehtml/Index.html#transorigpointerfield) instead of [transOrigPointerField](https://docs.typo3.org/m/typo3/reference-tca/main/en-us/singlehtml/Index.html#transorigpointerfield).

While in most cases they **should** be identical (when the translation was created in TYPO3), there are cases (e.g. imported translations) where only the `transOrigPointer` (e.g. `l10n_parent`) is set. That's why in most tests this won't come up.