### PR TITLE
[WIP] [FEATURE] de translations for backend labels as local file

### DIFF
--- a/Resources/Private/Language/Backend/de.ControlCenter.xlf
+++ b/Resources/Private/Language/Backend/de.ControlCenter.xlf
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" original="" datatype="plaintext" date="2022-10-06T14:23:19+02:00">
+        <body>
+            <trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
+                <source>TemplaVoilà! Plus Control Center</source>
+                <target>TemplaVoilà! Plus Kontrollzentrum</target>
+            </trans-unit>
+            <trans-unit id="title" resname="title">
+                <source>TemplaVoilà! Plus Control Center</source>
+                <target>TemplaVoilà! Plus Kontrollzentrum</target>
+            </trans-unit>
+            <trans-unit id="datastructures" resname="datastructures">
+                <source>Data Structures</source>
+                <target>Datenstrukturen (DataStructures)</target>
+            </trans-unit>
+            <trans-unit id="datastructures.description" resname="datastructures.description">
+                <source>Data Structures define the elements and areas that are used to structure the content of a mapping.</source>
+                <target>Datenstrukturen definieren die Elemente und Bereiche die für die Strukturierung der Inhalte einer Zuordnung genutzt werden.</target>
+            </trans-unit>
+            <trans-unit id="mappings" resname="mappings">
+                <source>Mappings</source>
+                <target>Zuordnungen (Mappings)</target>
+            </trans-unit>
+            <trans-unit id="mappings.description" resname="mappings.description">
+                <source>Mappings allow to define which TemplaVoilà! Plus configuration should be used for a specific page or content element.</source>
+                <target>Zuordnungen erlauben festzulegen welche TemplaVoilà! Plus Konfiguration für eine ausgewählte Seite oder ein ausgewähltes Inhaltselement genutzt werden.</target>
+            </trans-unit>
+            <trans-unit id="templates" resname="templates">
+                <source>Templates</source>
+                <target>Vorlagen (Templates)</target>
+            </trans-unit>
+            <trans-unit id="templates.description" resname="templates.description">
+                <source>Templates define which elements should be mapped to specific parts of an e.g. HTML template in order to create the output.</source>
+                <target>Vorlagen definieren welche Elemente zu welchen Bereichen einer bspw. HTML-Vorlage zugeordnet werden sollen, um die Ausgabe zu realisieren.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/Backend/de.PageLayout.xlf
+++ b/Resources/Private/Language/Backend/de.PageLayout.xlf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" target-language="de" original="" datatype="plaintext" date="2022-10-26T10:50:34+02:00">
+    <file source-language="en" target-language="de" original="" datatype="plaintext" date="2022-10-26T21:37:11+02:00">
         <body>
             <trans-unit id="clipboardAriaLabel" resname="clipboardAriaLabel">
-                <source>You can drag items from the page to add them to the clipboard, or open a filled clipboard to drag items to the page.</source>
-                <target>Seiteninhalte können hierhin verschoben werden, um sie der Zwischenablage hinzuzufügen; Alternativ können sie eine gefüllte Zwischenablage öffnen um Elemente auf die Seite zu ziehen.</target>
+                <source>You can drag items from the page to this icon to add them to the clipboard, or open a filled clipboard to drag items to the page.</source>
+                <target>Seiteninhalte können auf diese Schaltfläche verschoben werden, um sie der Zwischenablage hinzuzufügen; Alternativ können sie eine gefüllte Zwischenablage öffnen um Elemente auf die Seite zu ziehen.</target>
             </trans-unit>
             <trans-unit id="clipboardCopy" resname="clipboardCopy">
                 <source>Copy element</source>
@@ -25,6 +25,10 @@
             <trans-unit id="clipboardReference" resname="clipboardReference">
                 <source>Reference element</source>
                 <target>Element referenzieren</target>
+            </trans-unit>
+            <trans-unit id="configAriaLabel" resname="configAriaLabel">
+                <source>Open the settings menu.</source>
+                <target>Einstellungen öffnen</target>
             </trans-unit>
             <trans-unit id="createCopyForTranslation" resname="createCopyForTranslation">
                 <source>Create a copy for translation &#34;%s (%s)&#34;</source>
@@ -143,8 +147,8 @@
                 <target>Seite</target>
             </trans-unit>
             <trans-unit id="newCeWizardAriaLabel" resname="newCeWizardAriaLabel">
-                <source>Click here to open the new content element wizard to add new content elements by dragging them to the page.</source>
-                <target>Hier ist das Menü für neue Inhaltselemente, die dann auf die Seite an die gewünschte Position gezogen werden können.</target>
+                <source>Click this icon to open the new content element wizard to add new content elements by dragging them to the page.</source>
+                <target>Diese Schaltfläche öffnet das Menü für neue Inhaltselemente, die dann auf die Seite an die gewünschte Position gezogen werden können.</target>
             </trans-unit>
             <trans-unit id="newCeWizardDesc" resname="newCeWizardDesc">
                 <source>Please select the content type you want to add from the appropriate tab and drag and drop its icon to the desired position.</source>
@@ -179,8 +183,8 @@
                 <target>Ordner</target>
             </trans-unit>
             <trans-unit id="trashAriaLabel" resname="trashAriaLabel">
-                <source>You can drag items from the page to here to remove them, or open a filled trash to drag items back to the page to restore them.</source>
-                <target>Seiteninhalte können hierhin verschoben werden, um sie zu entfernen; Alternativ können sie einen gefüllten Papierkorb öffnen um Elemente widerherzustellen, indem Sie diese auf die Seite ziehen.</target>
+                <source>You can drag items from the page to this icon to remove the content, or open a filled trash to drag items back to the page to restore them.</source>
+                <target>Seiteninhalte können auf diese Schaltfläche verschoben werden, um sie zu entfernen; Alternativ können sie einen gefüllten Papierkorb öffnen um Elemente widerherzustellen, indem Sie diese auf die Seite ziehen.</target>
             </trans-unit>
             <trans-unit id="trashDesc" resname="trashDesc">
                 <source>Please select the content element you want to add and drag and drop its icon to the desired position.</source>
@@ -189,6 +193,26 @@
             <trans-unit id="trashHeading" resname="trashHeading">
                 <source>Unused Elements</source>
                 <target>Nicht verwendete Elemente</target>
+            </trans-unit>
+            <trans-unit id="tutorial.editing.heading" resname="tutorial.editing.heading">
+                <source>Start editing your pages!</source>
+                <target>Die Seitenbearbeitung kann beginnen!</target>
+            </trans-unit>
+            <trans-unit id="tutorial.editing.introduction" resname="tutorial.editing.introduction">
+                <source>Just select the page you want to edit from the page tree to the left.</source>
+                <target>Im Seitenbaum zur linken kann nun die gewünschte Seite ausgewählt werden.</target>
+            </trans-unit>
+            <trans-unit id="tutorial.introduction" resname="tutorial.introduction">
+                <source>The page module focuses on editing the content elements of a page.&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;In general there are different page areas or fields for which you can add content.&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;The content elements themselves can be moved around via drag and drop. For adding&#xA;&#x9;&#x9;&#x9;&#x9;&#x9;or removing content refer to the sidebar icon</source>
+                <target>Das Seitenmodul befasst sich mit der Bearbeitung von Inhaltselementen auf der Seite.</target>
+            </trans-unit>
+            <trans-unit id="tutorial.sidebar.heading" resname="tutorial.sidebar.heading">
+                <source>Understanding the sidebar items</source>
+                <target>Funktionen des seitlichen Menüs</target>
+            </trans-unit>
+            <trans-unit id="tutorial.sidebar.introduction" resname="tutorial.sidebar.introduction">
+                <source>To the right you find a sidebar with some icons</source>
+                <target>Zur rechten findet sich das seitliche Menü mit folgenden Schaltflächen</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/Backend/de.PageLayout.xlf
+++ b/Resources/Private/Language/Backend/de.PageLayout.xlf
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" original="" datatype="plaintext" date="2022-10-06T14:19:30+02:00">
+        <body>
+            <trans-unit id="mlang_tabs_tab" resname="mlang_tabs_tab">
+                <source>Page</source>
+                <target>Seite</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
+                <source>This module allows you to create and edit webpages. It provides a template selector and management for different languages. This page module is part of the extension &#34;TemplaVoilà Plus&#34;.</source>
+                <target>Dieses Modul erlaubt die Erstellung und Bearbeitung von Seiten. Es erlaubt das Template auszuwählen und unterstützt verschiedene Sprachen. Dieses Seitenmodul ist Teil der Erweiterung &#34;TemplaVoilà Plus&#34;.</target>
+            </trans-unit>
+            <trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
+                <source>Create and edit pages</source>
+                <target>Seiten anlegen und bearbeiten</target>
+            </trans-unit>
+            <trans-unit id="title" resname="title">
+                <source>Page Module</source>
+                <target>Seitenmodul</target>
+            </trans-unit>
+            <trans-unit id="infoDefaultIntroduction" resname="infoDefaultIntroduction">
+                <source>If you wish to edit the content of a page, please click the page title in the page tree on the left.</source>
+                <target>Um die Inhalte einer Seite zu bearbeiten, auf den Seitentitel im Seitenbaum links klicken.</target>
+            </trans-unit>
+            <trans-unit id="infoPageNotFound" resname="infoPageNotFound">
+                <source>The requested page can&#39;t be found or is not accessible.</source>
+                <target>Die angeforderte Seite konnte nicht gefunden werden oder kann nicht zugegriffen werden.</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeShortcut" resname="titleDoktypeShortcut">
+                <source>Shortcut</source>
+                <target>Verweis</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeShortcutCannotEdit0" resname="infoDoktypeShortcutCannotEdit0">
+                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content from the selected page &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeShortcutCannotEdit1" resname="infoDoktypeShortcutCannotEdit1">
+                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content from the first sub page of current/selected page, which is &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der ersten Unterseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeShortcutCannotEdit2" resname="infoDoktypeShortcutCannotEdit2">
+                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content of a random sub page of current/selected page. Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt einer zufälligen Unterseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeShortcutCannotEdit3" resname="infoDoktypeShortcutCannotEdit3">
+                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content of parent page of current/selected page, which is &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der Elternseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="hintDoktypeShortcutJumpToDestination" resname="hintDoktypeShortcutJumpToDestination">
+                <source>Jump to shortcut destination</source>
+                <target>Zum Verweisziel springen</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeLink" resname="titleDoktypeLink">
+                <source>External URL</source>
+                <target>Externe URL</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeLinkCannotEdit" resname="infoDoktypeLinkCannotEdit">
+                <source>This page refers to the external address &#34;%s&#34;, you therefore cannot edit the content of this page directly.</source>
+                <target>Diese Seite verweist auf eine externe URL &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeLinkCannotEdit1" resname="infoDoktypeLinkCannotEdit1">
+                <source>This page refers to an external website, you therefore cannot edit the content of this page directly.</source>
+                <target>Diese Seite verweist auf eine externe Website. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeLinkCannotEdit2" resname="infoDoktypeLinkCannotEdit2">
+                <source>This page refers to an external FTP location, you therefore cannot edit the content of this page directly.</source>
+                <target>Diese Seite verweist auf eine externen FTP Server. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeLinkCannotEdit3" resname="infoDoktypeLinkCannotEdit3">
+                <source>This page refers to an email address, you therefore cannot edit the content of this page directly.</source>
+                <target>Diese Seite verweist auf eine E-Mail-Adresse. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="hintDoktypeLinkOpen" resname="hintDoktypeLinkOpen">
+                <source>Open external address (%s)</source>
+                <target>Zur externen Adresse springen (%s)</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeSysfolder" resname="titleDoktypeSysfolder">
+                <source>System folder</source>
+                <target>Ordner</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeSysfolderCannotEdit" resname="infoDoktypeSysfolderCannotEdit">
+                <source>The current page is of the type &#34;Sysfolder&#34;. Sysfolders usually don&#39;t contain content elements but are used for collecting other types of records in a single folder.</source>
+                <target>Diese Seite ist vom Typ &#34;Ordner&#34;. Order enthalten üblicherweise keine Seiteninhalte, sondern werden für andere Arten von Datensätzen genutzt.</target>
+            </trans-unit>
+            <trans-unit id="hintDoktypeSysfolderOpen" resname="hintDoktypeSysfolderOpen">
+                <source>Switch to list view</source>
+                <target>Zur Listenansicht wechseln</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeMountpoint" resname="titleDoktypeMountpoint">
+                <source>Mount point</source>
+                <target>Einstiegspunkt</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeMountpointCannotEdit" resname="infoDoktypeMountpointCannotEdit">
+                <source>This page acts as a mount point and its content is being replaced by another page (&#34;%s&#34;). Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist ein Einstiegspunkt, weshalb der Seiteninhalt durch den einer anderen Seite (%s) ersetzt wird. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="hintDoktypeMountpointOpen" resname="hintDoktypeMountpointOpen">
+                <source>Jump to source page of this mount point</source>
+                <target>Zur als Einstiegspunkt genutzten Seite wechseln.</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeSpacer" resname="titleDoktypeSpacer">
+                <source>Spacer</source>
+                <target>Trennzeichen für Menü</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeSpacerCannotEdit" resname="infoDoktypeSpacerCannotEdit">
+                <source>The current page is of the type &#34;Spacer&#34; and therfore cannot be edited.</source>
+                <target>Diese Seite ist vom Typ &#34;Trennzeichen&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoTitleSelectTemplateDesign" resname="infoTitleSelectTemplateDesign">
+                <source>Template Design</source>
+                <target>Template Design</target>
+            </trans-unit>
+            <trans-unit id="infoContentSelectTemplateDesign" resname="infoContentSelectTemplateDesign">
+                <source>Please select a template design for this page.</source>
+                <target>Bitte ein Template Design für diese Seite auswählen</target>
+            </trans-unit>
+            <trans-unit id="infoTitleMissingEditRights" resname="infoTitleMissingEditRights">
+                <source>Your user settings don&#39;t allow creating, moving or removing elements from this page.</source>
+                <target>Die Benutzereinstellungen erlauben nicht das Inhalte auf dieser Seite erzeugt, verschoben oder entfernt werden.</target>
+            </trans-unit>
+            <trans-unit id="infoContentMissingEditRights" resname="infoContentMissingEditRights">
+                <source>Your settings indicate that you either don&#39;t have the general right to edit page content, or you&#39;re not allowed to modify required tables or you&#39;re not allowed to edit the content fields. We suggest you recheck the settings or get in touch with your technical support.</source>
+                <target>Die Benutzereinstellungen deuten darauf hin, dass entweder keine Berechtigung zur Bearbeitung der Seite existieren, oder keine Berechtigung zur Bearbeitung der relevanten Datentypen und Inhaltsfelder. Der technische Support sollte kontaktiert werden um die Einstellungen und Berechtigungen zu prüfen.</target>
+            </trans-unit>
+            <trans-unit id="infoElementFromOtherPage" resname="infoElementFromOtherPage">
+                <source>This is a reference to an element on page %2$d.</source>
+                <target>Das ist eine Referenz zu einem Element of Seite %2$d.</target>
+            </trans-unit>
+            <trans-unit id="infoElementUsedMultipleTimes" resname="infoElementUsedMultipleTimes">
+                <source>This element has been used %s times on this page!</source>
+                <target>Dieses Element wird %smal auf dieser Seite verwendet!</target>
+            </trans-unit>
+            <trans-unit id="labelLocalizations" resname="labelLocalizations">
+                <source>Localizations</source>
+                <target>Lokalisierungen</target>
+            </trans-unit>
+            <trans-unit id="createCopyForTranslation" resname="createCopyForTranslation">
+                <source>Create a copy for translation &#34;%s (%s)&#34;</source>
+                <target>Eine Kopie für die Übersetzung erzeugen</target>
+            </trans-unit>
+            <trans-unit id="newContentElementWizard.fce" resname="newContentElementWizard.fce">
+                <source>FCE</source>
+                <target>FCE</target>
+            </trans-unit>
+            <trans-unit id="error.fce.noMapping" resname="error.fce.noMapping">
+                <source>Error: This FCE has no mapping set.</source>
+                <target>Fehler: Dieses FCE hat kein definiertes Mapping.</target>
+            </trans-unit>
+            <trans-unit id="clipboardHeading" resname="clipboardHeading">
+                <source>Clipboard</source>
+                <target>Zwischenablage</target>
+            </trans-unit>
+            <trans-unit id="clipboardDesc" resname="clipboardDesc">
+                <source>Please select the content element you want to add and drag and drop its icon to the desired position.</source>
+                <target>Das Inhaltselement, das hinzugefügt werden soll mit dem Icon per Drag-and-Drop and die gewünschte Position ziehen.</target>
+            </trans-unit>
+            <trans-unit id="clipboardMove" resname="clipboardMove">
+                <source>Move element</source>
+                <target>Element verschieben</target>
+            </trans-unit>
+            <trans-unit id="clipboardCopy" resname="clipboardCopy">
+                <source>Copy element</source>
+                <target>Element kopieren</target>
+            </trans-unit>
+            <trans-unit id="clipboardReference" resname="clipboardReference">
+                <source>Reference element</source>
+                <target>Element referenzieren</target>
+            </trans-unit>
+            <trans-unit id="newCeWizardDesc" resname="newCeWizardDesc">
+                <source>Please select the content type you want to add from the appropriate tab and drag and drop its icon to the desired position.</source>
+                <target>Den Inhaltstyp, der hinzugefügt werden soll mit dem Icon per Drag-and-Drop and die gewünschte Position ziehen.</target>
+            </trans-unit>
+            <trans-unit id="trashHeading" resname="trashHeading">
+                <source>Unused Elements</source>
+                <target>Nicht verwendete Elemente</target>
+            </trans-unit>
+            <trans-unit id="trashDesc" resname="trashDesc">
+                <source>Please select the content element you want to add and drag and drop its icon to the desired position.</source>
+                <target>Das Inhaltselement, das hinzugefügt werden soll mit dem Icon per Drag-and-Drop and die gewünschte Position ziehen.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/Backend/de.PageLayout.xlf
+++ b/Resources/Private/Language/Backend/de.PageLayout.xlf
@@ -1,58 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns:t3="http://typo3.org/schemas/xliff" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" target-language="de" original="" datatype="plaintext" date="2022-10-06T14:19:30+02:00">
+    <file source-language="en" target-language="de" original="" datatype="plaintext" date="2022-10-26T10:50:34+02:00">
         <body>
-            <trans-unit id="mlang_tabs_tab" resname="mlang_tabs_tab">
-                <source>Page</source>
-                <target>Seite</target>
+            <trans-unit id="clipboardAriaLabel" resname="clipboardAriaLabel">
+                <source>You can drag items from the page to add them to the clipboard, or open a filled clipboard to drag items to the page.</source>
+                <target>Seiteninhalte können hierhin verschoben werden, um sie der Zwischenablage hinzuzufügen; Alternativ können sie eine gefüllte Zwischenablage öffnen um Elemente auf die Seite zu ziehen.</target>
             </trans-unit>
-            <trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
-                <source>This module allows you to create and edit webpages. It provides a template selector and management for different languages. This page module is part of the extension &#34;TemplaVoilà Plus&#34;.</source>
-                <target>Dieses Modul erlaubt die Erstellung und Bearbeitung von Seiten. Es erlaubt das Template auszuwählen und unterstützt verschiedene Sprachen. Dieses Seitenmodul ist Teil der Erweiterung &#34;TemplaVoilà Plus&#34;.</target>
+            <trans-unit id="clipboardCopy" resname="clipboardCopy">
+                <source>Copy element</source>
+                <target>Element kopieren</target>
             </trans-unit>
-            <trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
-                <source>Create and edit pages</source>
-                <target>Seiten anlegen und bearbeiten</target>
+            <trans-unit id="clipboardDesc" resname="clipboardDesc">
+                <source>Please select the content element you want to add and drag and drop its icon to the desired position.</source>
+                <target>Das Inhaltselement, das hinzugefügt werden soll mit dem Icon per Drag-and-Drop and die gewünschte Position ziehen.</target>
             </trans-unit>
-            <trans-unit id="title" resname="title">
-                <source>Page Module</source>
-                <target>Seitenmodul</target>
+            <trans-unit id="clipboardHeading" resname="clipboardHeading">
+                <source>Clipboard</source>
+                <target>Zwischenablage</target>
             </trans-unit>
-            <trans-unit id="infoDefaultIntroduction" resname="infoDefaultIntroduction">
-                <source>If you wish to edit the content of a page, please click the page title in the page tree on the left.</source>
-                <target>Um die Inhalte einer Seite zu bearbeiten, auf den Seitentitel im Seitenbaum links klicken.</target>
+            <trans-unit id="clipboardMove" resname="clipboardMove">
+                <source>Move element</source>
+                <target>Element verschieben</target>
             </trans-unit>
-            <trans-unit id="infoPageNotFound" resname="infoPageNotFound">
-                <source>The requested page can&#39;t be found or is not accessible.</source>
-                <target>Die angeforderte Seite konnte nicht gefunden werden oder kann nicht zugegriffen werden.</target>
+            <trans-unit id="clipboardReference" resname="clipboardReference">
+                <source>Reference element</source>
+                <target>Element referenzieren</target>
             </trans-unit>
-            <trans-unit id="titleDoktypeShortcut" resname="titleDoktypeShortcut">
-                <source>Shortcut</source>
-                <target>Verweis</target>
+            <trans-unit id="createCopyForTranslation" resname="createCopyForTranslation">
+                <source>Create a copy for translation &#34;%s (%s)&#34;</source>
+                <target>Eine Kopie für die Übersetzung erzeugen</target>
             </trans-unit>
-            <trans-unit id="infoDoktypeShortcutCannotEdit0" resname="infoDoktypeShortcutCannotEdit0">
-                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content from the selected page &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
-                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            <trans-unit id="error.fce.noMapping" resname="error.fce.noMapping">
+                <source>Error: This FCE has no mapping set.</source>
+                <target>Fehler: Dieses FCE hat kein definiertes Mapping.</target>
             </trans-unit>
-            <trans-unit id="infoDoktypeShortcutCannotEdit1" resname="infoDoktypeShortcutCannotEdit1">
-                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content from the first sub page of current/selected page, which is &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
-                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der ersten Unterseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            <trans-unit id="hintDoktypeLinkOpen" resname="hintDoktypeLinkOpen">
+                <source>Open external address (%s)</source>
+                <target>Zur externen Adresse springen (%s)</target>
             </trans-unit>
-            <trans-unit id="infoDoktypeShortcutCannotEdit2" resname="infoDoktypeShortcutCannotEdit2">
-                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content of a random sub page of current/selected page. Therefore you cannot edit the content of this page directly.</source>
-                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt einer zufälligen Unterseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
-            </trans-unit>
-            <trans-unit id="infoDoktypeShortcutCannotEdit3" resname="infoDoktypeShortcutCannotEdit3">
-                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content of parent page of current/selected page, which is &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
-                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der Elternseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            <trans-unit id="hintDoktypeMountpointOpen" resname="hintDoktypeMountpointOpen">
+                <source>Jump to source page of this mount point</source>
+                <target>Zur als Einstiegspunkt genutzten Seite wechseln.</target>
             </trans-unit>
             <trans-unit id="hintDoktypeShortcutJumpToDestination" resname="hintDoktypeShortcutJumpToDestination">
                 <source>Jump to shortcut destination</source>
                 <target>Zum Verweisziel springen</target>
             </trans-unit>
-            <trans-unit id="titleDoktypeLink" resname="titleDoktypeLink">
-                <source>External URL</source>
-                <target>Externe URL</target>
+            <trans-unit id="hintDoktypeSysfolderOpen" resname="hintDoktypeSysfolderOpen">
+                <source>Switch to list view</source>
+                <target>Zur Listenansicht wechseln</target>
+            </trans-unit>
+            <trans-unit id="infoContentMissingEditRights" resname="infoContentMissingEditRights">
+                <source>Your settings indicate that you either don&#39;t have the general right to edit page content, or you&#39;re not allowed to modify required tables or you&#39;re not allowed to edit the content fields. We suggest you recheck the settings or get in touch with your technical support.</source>
+                <target>Die Benutzereinstellungen deuten darauf hin, dass entweder keine Berechtigung zur Bearbeitung der Seite existieren, oder keine Berechtigung zur Bearbeitung der relevanten Datentypen und Inhaltsfelder. Der technische Support sollte kontaktiert werden um die Einstellungen und Berechtigungen zu prüfen.</target>
+            </trans-unit>
+            <trans-unit id="infoContentSelectTemplateDesign" resname="infoContentSelectTemplateDesign">
+                <source>Please select a template design for this page.</source>
+                <target>Bitte ein Template Design für diese Seite auswählen</target>
+            </trans-unit>
+            <trans-unit id="infoDefaultIntroduction" resname="infoDefaultIntroduction">
+                <source>If you wish to edit the content of a page, please click the page title in the page tree on the left.</source>
+                <target>Um die Inhalte einer Seite zu bearbeiten, auf den Seitentitel im Seitenbaum links klicken.</target>
             </trans-unit>
             <trans-unit id="infoDoktypeLinkCannotEdit" resname="infoDoktypeLinkCannotEdit">
                 <source>This page refers to the external address &#34;%s&#34;, you therefore cannot edit the content of this page directly.</source>
@@ -70,57 +78,33 @@
                 <source>This page refers to an email address, you therefore cannot edit the content of this page directly.</source>
                 <target>Diese Seite verweist auf eine E-Mail-Adresse. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
             </trans-unit>
-            <trans-unit id="hintDoktypeLinkOpen" resname="hintDoktypeLinkOpen">
-                <source>Open external address (%s)</source>
-                <target>Zur externen Adresse springen (%s)</target>
-            </trans-unit>
-            <trans-unit id="titleDoktypeSysfolder" resname="titleDoktypeSysfolder">
-                <source>System folder</source>
-                <target>Ordner</target>
-            </trans-unit>
-            <trans-unit id="infoDoktypeSysfolderCannotEdit" resname="infoDoktypeSysfolderCannotEdit">
-                <source>The current page is of the type &#34;Sysfolder&#34;. Sysfolders usually don&#39;t contain content elements but are used for collecting other types of records in a single folder.</source>
-                <target>Diese Seite ist vom Typ &#34;Ordner&#34;. Order enthalten üblicherweise keine Seiteninhalte, sondern werden für andere Arten von Datensätzen genutzt.</target>
-            </trans-unit>
-            <trans-unit id="hintDoktypeSysfolderOpen" resname="hintDoktypeSysfolderOpen">
-                <source>Switch to list view</source>
-                <target>Zur Listenansicht wechseln</target>
-            </trans-unit>
-            <trans-unit id="titleDoktypeMountpoint" resname="titleDoktypeMountpoint">
-                <source>Mount point</source>
-                <target>Einstiegspunkt</target>
-            </trans-unit>
             <trans-unit id="infoDoktypeMountpointCannotEdit" resname="infoDoktypeMountpointCannotEdit">
                 <source>This page acts as a mount point and its content is being replaced by another page (&#34;%s&#34;). Therefore you cannot edit the content of this page directly.</source>
                 <target>Diese Seite ist ein Einstiegspunkt, weshalb der Seiteninhalt durch den einer anderen Seite (%s) ersetzt wird. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
             </trans-unit>
-            <trans-unit id="hintDoktypeMountpointOpen" resname="hintDoktypeMountpointOpen">
-                <source>Jump to source page of this mount point</source>
-                <target>Zur als Einstiegspunkt genutzten Seite wechseln.</target>
+            <trans-unit id="infoDoktypeShortcutCannotEdit0" resname="infoDoktypeShortcutCannotEdit0">
+                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content from the selected page &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
             </trans-unit>
-            <trans-unit id="titleDoktypeSpacer" resname="titleDoktypeSpacer">
-                <source>Spacer</source>
-                <target>Trennzeichen für Menü</target>
+            <trans-unit id="infoDoktypeShortcutCannotEdit1" resname="infoDoktypeShortcutCannotEdit1">
+                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content from the first sub page of current/selected page, which is &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der ersten Unterseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeShortcutCannotEdit2" resname="infoDoktypeShortcutCannotEdit2">
+                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content of a random sub page of current/selected page. Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt einer zufälligen Unterseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
+            </trans-unit>
+            <trans-unit id="infoDoktypeShortcutCannotEdit3" resname="infoDoktypeShortcutCannotEdit3">
+                <source>This page is of the type &#34;shortcut&#34;. Instead of having content on its own, this page shows the content of parent page of current/selected page, which is &#34;%s&#34;. Therefore you cannot edit the content of this page directly.</source>
+                <target>Diese Seite ist vom Typ &#34;Verweis&#34;. Anstelle von eigenen Inhalten, zeigt diese Seite den Inhalt der Elternseite der aktuellen oder ausgewählten Seite &#34;%s&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
             </trans-unit>
             <trans-unit id="infoDoktypeSpacerCannotEdit" resname="infoDoktypeSpacerCannotEdit">
                 <source>The current page is of the type &#34;Spacer&#34; and therfore cannot be edited.</source>
                 <target>Diese Seite ist vom Typ &#34;Trennzeichen&#34;. Daher kann der Inhalt dieser Seite nicht bearbeitet werden.</target>
             </trans-unit>
-            <trans-unit id="infoTitleSelectTemplateDesign" resname="infoTitleSelectTemplateDesign">
-                <source>Template Design</source>
-                <target>Template Design</target>
-            </trans-unit>
-            <trans-unit id="infoContentSelectTemplateDesign" resname="infoContentSelectTemplateDesign">
-                <source>Please select a template design for this page.</source>
-                <target>Bitte ein Template Design für diese Seite auswählen</target>
-            </trans-unit>
-            <trans-unit id="infoTitleMissingEditRights" resname="infoTitleMissingEditRights">
-                <source>Your user settings don&#39;t allow creating, moving or removing elements from this page.</source>
-                <target>Die Benutzereinstellungen erlauben nicht das Inhalte auf dieser Seite erzeugt, verschoben oder entfernt werden.</target>
-            </trans-unit>
-            <trans-unit id="infoContentMissingEditRights" resname="infoContentMissingEditRights">
-                <source>Your settings indicate that you either don&#39;t have the general right to edit page content, or you&#39;re not allowed to modify required tables or you&#39;re not allowed to edit the content fields. We suggest you recheck the settings or get in touch with your technical support.</source>
-                <target>Die Benutzereinstellungen deuten darauf hin, dass entweder keine Berechtigung zur Bearbeitung der Seite existieren, oder keine Berechtigung zur Bearbeitung der relevanten Datentypen und Inhaltsfelder. Der technische Support sollte kontaktiert werden um die Einstellungen und Berechtigungen zu prüfen.</target>
+            <trans-unit id="infoDoktypeSysfolderCannotEdit" resname="infoDoktypeSysfolderCannotEdit">
+                <source>The current page is of the type &#34;Sysfolder&#34;. Sysfolders usually don&#39;t contain content elements but are used for collecting other types of records in a single folder.</source>
+                <target>Diese Seite ist vom Typ &#34;Ordner&#34;. Order enthalten üblicherweise keine Seiteninhalte, sondern werden für andere Arten von Datensätzen genutzt.</target>
             </trans-unit>
             <trans-unit id="infoElementFromOtherPage" resname="infoElementFromOtherPage">
                 <source>This is a reference to an element on page %2$d.</source>
@@ -130,53 +114,81 @@
                 <source>This element has been used %s times on this page!</source>
                 <target>Dieses Element wird %smal auf dieser Seite verwendet!</target>
             </trans-unit>
+            <trans-unit id="infoPageNotFound" resname="infoPageNotFound">
+                <source>The requested page can&#39;t be found or is not accessible.</source>
+                <target>Die angeforderte Seite konnte nicht gefunden werden oder kann nicht zugegriffen werden.</target>
+            </trans-unit>
+            <trans-unit id="infoTitleMissingEditRights" resname="infoTitleMissingEditRights">
+                <source>Your user settings don&#39;t allow creating, moving or removing elements from this page.</source>
+                <target>Die Benutzereinstellungen erlauben nicht das Inhalte auf dieser Seite erzeugt, verschoben oder entfernt werden.</target>
+            </trans-unit>
+            <trans-unit id="infoTitleSelectTemplateDesign" resname="infoTitleSelectTemplateDesign">
+                <source>Template Design</source>
+                <target>Template Design</target>
+            </trans-unit>
             <trans-unit id="labelLocalizations" resname="labelLocalizations">
                 <source>Localizations</source>
                 <target>Lokalisierungen</target>
             </trans-unit>
-            <trans-unit id="createCopyForTranslation" resname="createCopyForTranslation">
-                <source>Create a copy for translation &#34;%s (%s)&#34;</source>
-                <target>Eine Kopie für die Übersetzung erzeugen</target>
+            <trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
+                <source>This module allows you to create and edit webpages. It provides a template selector and management for different languages. This page module is part of the extension &#34;TemplaVoilà Plus&#34;.</source>
+                <target>Dieses Modul erlaubt die Erstellung und Bearbeitung von Seiten. Es erlaubt das Template auszuwählen und unterstützt verschiedene Sprachen. Dieses Seitenmodul ist Teil der Erweiterung &#34;TemplaVoilà Plus&#34;.</target>
             </trans-unit>
-            <trans-unit id="newContentElementWizard.fce" resname="newContentElementWizard.fce">
-                <source>FCE</source>
-                <target>FCE</target>
+            <trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
+                <source>Create and edit pages</source>
+                <target>Seiten anlegen und bearbeiten</target>
             </trans-unit>
-            <trans-unit id="error.fce.noMapping" resname="error.fce.noMapping">
-                <source>Error: This FCE has no mapping set.</source>
-                <target>Fehler: Dieses FCE hat kein definiertes Mapping.</target>
+            <trans-unit id="mlang_tabs_tab" resname="mlang_tabs_tab">
+                <source>Page</source>
+                <target>Seite</target>
             </trans-unit>
-            <trans-unit id="clipboardHeading" resname="clipboardHeading">
-                <source>Clipboard</source>
-                <target>Zwischenablage</target>
-            </trans-unit>
-            <trans-unit id="clipboardDesc" resname="clipboardDesc">
-                <source>Please select the content element you want to add and drag and drop its icon to the desired position.</source>
-                <target>Das Inhaltselement, das hinzugefügt werden soll mit dem Icon per Drag-and-Drop and die gewünschte Position ziehen.</target>
-            </trans-unit>
-            <trans-unit id="clipboardMove" resname="clipboardMove">
-                <source>Move element</source>
-                <target>Element verschieben</target>
-            </trans-unit>
-            <trans-unit id="clipboardCopy" resname="clipboardCopy">
-                <source>Copy element</source>
-                <target>Element kopieren</target>
-            </trans-unit>
-            <trans-unit id="clipboardReference" resname="clipboardReference">
-                <source>Reference element</source>
-                <target>Element referenzieren</target>
+            <trans-unit id="newCeWizardAriaLabel" resname="newCeWizardAriaLabel">
+                <source>Click here to open the new content element wizard to add new content elements by dragging them to the page.</source>
+                <target>Hier ist das Menü für neue Inhaltselemente, die dann auf die Seite an die gewünschte Position gezogen werden können.</target>
             </trans-unit>
             <trans-unit id="newCeWizardDesc" resname="newCeWizardDesc">
                 <source>Please select the content type you want to add from the appropriate tab and drag and drop its icon to the desired position.</source>
                 <target>Den Inhaltstyp, der hinzugefügt werden soll mit dem Icon per Drag-and-Drop and die gewünschte Position ziehen.</target>
             </trans-unit>
-            <trans-unit id="trashHeading" resname="trashHeading">
-                <source>Unused Elements</source>
-                <target>Nicht verwendete Elemente</target>
+            <trans-unit id="newContentElementWizard.fce" resname="newContentElementWizard.fce">
+                <source>FCE</source>
+                <target>FCE</target>
+            </trans-unit>
+            <trans-unit id="title" resname="title">
+                <source>Page Module</source>
+                <target>Seitenmodul</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeLink" resname="titleDoktypeLink">
+                <source>External URL</source>
+                <target>Externe URL</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeMountpoint" resname="titleDoktypeMountpoint">
+                <source>Mount point</source>
+                <target>Einstiegspunkt</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeShortcut" resname="titleDoktypeShortcut">
+                <source>Shortcut</source>
+                <target>Verweis</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeSpacer" resname="titleDoktypeSpacer">
+                <source>Spacer</source>
+                <target>Trennzeichen für Menü</target>
+            </trans-unit>
+            <trans-unit id="titleDoktypeSysfolder" resname="titleDoktypeSysfolder">
+                <source>System folder</source>
+                <target>Ordner</target>
+            </trans-unit>
+            <trans-unit id="trashAriaLabel" resname="trashAriaLabel">
+                <source>You can drag items from the page to here to remove them, or open a filled trash to drag items back to the page to restore them.</source>
+                <target>Seiteninhalte können hierhin verschoben werden, um sie zu entfernen; Alternativ können sie einen gefüllten Papierkorb öffnen um Elemente widerherzustellen, indem Sie diese auf die Seite ziehen.</target>
             </trans-unit>
             <trans-unit id="trashDesc" resname="trashDesc">
                 <source>Please select the content element you want to add and drag and drop its icon to the desired position.</source>
                 <target>Das Inhaltselement, das hinzugefügt werden soll mit dem Icon per Drag-and-Drop and die gewünschte Position ziehen.</target>
+            </trans-unit>
+            <trans-unit id="trashHeading" resname="trashHeading">
+                <source>Unused Elements</source>
+                <target>Nicht verwendete Elemente</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
For my current project I need a German translation of the page module for editors. From history I know that

1. it was not possible for TVP to use the TYPO3 l10n infrastructure
2. there is https://github.com/T3Voila/templavoilaplus-languagefiles 

So either we would need to retry (1) (from Slack #cig-crowdin-localization it seems this is not so complex anymore, but just asking) or automate (2) in order to make this work in the long run.

As resources are scarce I'll meanwhile provide this PR here as an alternative. In order to keep everything clean this probably won't be merged (although it won't hurt), however still this is now available for everyone using `composer-patches` to ease adoption.