### PR TITLE
[BUGFIX] non-admins can't add content

### DIFF
--- a/Classes/Controller/Backend/PageLayoutController.php
+++ b/Classes/Controller/Backend/PageLayoutController.php
@@ -251,7 +251,7 @@ class PageLayoutController extends ActionController
         $this->view->assign('pageMessages', $this->getFlashMessageQueue('TVP')->getAllMessages());
 
         $this->view->assign('calcPerms', $this->calcPerms);
-        $this->view->assign('basicEditRights', $this->hasBasicEditRights());
+        $this->view->assign('basicEditRights', $this->hasBasicEditRights(isset($this->pageInfo['uid']) ? 'pages' : null, isset($this->pageInfo['uid']) ? $this->pageInfo : null));
         $this->view->assign('clipboard', $this->clipboard2fluid());
 
 

--- a/Classes/Controller/Backend/PageLayoutController.php
+++ b/Classes/Controller/Backend/PageLayoutController.php
@@ -58,7 +58,7 @@ class PageLayoutController extends ActionController
     /**
      * Record of current page with _path information BackendUtility::readPageAccess
      *
-     * @var array
+     * @var array|false
      */
     protected $pageInfo;
 
@@ -188,7 +188,9 @@ class PageLayoutController extends ActionController
 
         $this->pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
-        $this->view->getModuleTemplate()->getDocHeaderComponent()->setMetaInformation($this->pageInfo);
+        if ($this->pageInfo !== false) {
+            $this->view->getModuleTemplate()->getDocHeaderComponent()->setMetaInformation($this->pageInfo);
+        }
         $this->view->getModuleTemplate()->setFlashMessageQueue($this->getFlashMessageQueue());
 
         $contentHeader = '';


### PR DESCRIPTION
- editors which just login only see an exception if no page is selected in backend tree, because pageinfo is false
- the calcperm call for non-admins is missing parameters, thus always returning false, thus disabling the newCE sidebar button