### PR TITLE
[BUGFIX] ddev breaks processValue wraps

### DIFF
--- a/Classes/Handler/Render/XpathRenderHandler.php
+++ b/Classes/Handler/Render/XpathRenderHandler.php
@@ -211,7 +211,7 @@ class XpathRenderHandler implements RenderHandlerInterface
                     $tmpDoc = new \DOMDocument();
                     /** Add own tag to prevent automagical adding of <p> Tag around Tagless content */
                     /** Use LIBXML_HTML_NOIMPLIED and LIBXML_HTML_NODEFDTD so we don't get confused by extra added doctype, html and body nodes */
-                    $tmpDoc->loadHTML('<?xml encoding="utf-8" ?><__TEMPLAVOILAPLUS__>' . $processedValues[$fieldName] . '</__TEMPLAVOILAPLUS__>', $this->libXmlConfig);
+                    $tmpDoc->loadHTML('<?xml encoding="utf-8" ?><templavoilapluscontentwrap>' . $processedValues[$fieldName] . '</templavoilapluscontentwrap>', $this->libXmlConfig);
 
                     /** lastChild is our own added Tag from above */
                     foreach ($tmpDoc->lastChild->childNodes as $importNode) {
@@ -248,7 +248,7 @@ class XpathRenderHandler implements RenderHandlerInterface
                     $tmpDoc = new \DOMDocument();
                     /** Add own tag to prevent automagical adding of <p> Tag around Tagless content */
                     /** Use LIBXML_HTML_NOIMPLIED and LIBXML_HTML_NODEFDTD so we don't get confused by extra added doctype, html and body nodes */
-                    $tmpDoc->loadHTML('<?xml encoding="utf-8" ?><__TEMPLAVOILAPLUS__>' . $processedValues[$fieldName] . '</__TEMPLAVOILAPLUS__>', $this->libXmlConfig);
+                    $tmpDoc->loadHTML('<?xml encoding="utf-8" ?><templavoilapluscontentwrap>' . $processedValues[$fieldName] . '</templavoilapluscontentwrap>', $this->libXmlConfig);
 
                     $isFirst = true;
 


### PR DESCRIPTION
Using ddev 1.21.1 with php 7.4 my working config shows up broken. Multiple wraps are missing or the label `__TEMPLAVOILAPLUS__>` is output. This points to XpathRenderHandler::processValue*().
Replacing the tag with just lower case ascii immediatly solved the problem. Seems a hiccup in an XML lib, because according to XML spec underscore is perfectly fine. But this will make it a bit more robust