### PR TITLE
[TASK] json settings output should be userSettings only

### DIFF
--- a/Resources/Private/Templates/Backend/PageLayout/Show.html
+++ b/Resources/Private/Templates/Backend/PageLayout/Show.html
@@ -42,7 +42,7 @@
 
     <f:render section="FlashMessage" arguments="{_all}" />
 
-    <div id="moduleWrapper" data-identifier="moduleWrapper" class="hidden" data-tvp-page-id="{pageId}" data-tvp-page-edit-rights="{basicEditRights}" data-tvp-page-dok-type="{pageDoktype}" data-tvp-settings="{settings.configuration -> f:format.json()}">
+    <div id="moduleWrapper" data-identifier="moduleWrapper" class="hidden" data-tvp-page-id="{pageId}" data-tvp-page-edit-rights="{basicEditRights}" data-tvp-page-dok-type="{pageDoktype}" data-tvp-usersettings="{settings.configuration.userSettings -> f:format.json()}">
 
         <section id="tvp-component-sidebar-left" class="tvp-component-sidebar" data-identifier="tvpComponentSidebarLeft">
             <f:render section="SidebarContentTree" />

--- a/Resources/Public/JavaScript/PageLayout.js
+++ b/Resources/Public/JavaScript/PageLayout.js
@@ -22,8 +22,8 @@ define([
     PageLayout.initialize = function() {
 
         // Check for Dark Mode
-        var settings = $('#moduleWrapper').data('tvpSettings');
-        if (settings.userSettings.enableDarkMode) {
+        var userSettings = $('#moduleWrapper').data('tvpUsersettings');
+        if (userSettings.enableDarkMode) {
             $('body').addClass('dark-mode-on');
         }
         // Enable Sidebar Elements


### PR DESCRIPTION
currently `settings.configuration` was output as json. That included the full TCA. this attribute slowed down page rendering in general and developer console for quick CSS fixes too.

as `settings.configuration.tca` is used in fluid this must stay; as the javascript only accesses userSettings, I propose to just output usersettings. 

Especially in Safari this is a major performance boost