### PR TITLE
[FEATURE] introduce languageAspect and pages.l18n_cfg information to settings

### DIFF
--- a/Classes/Controller/Backend/PageLayoutController.php
+++ b/Classes/Controller/Backend/PageLayoutController.php
@@ -104,6 +104,11 @@ class PageLayoutController extends ActionController
     protected $currentLanguageUid = 0;
 
     /**
+     * Contains the current language mode (strict, fallback, fallback-to-what)
+     */
+    protected $languageAspect = null;
+
+    /**
      * Contains records of all available languages (not hidden, with ISOcode), including the default
      * language and multiple languages. Used for displaying the flags for content elements, set in init().
      *
@@ -152,6 +157,7 @@ class PageLayoutController extends ActionController
             'allAvailableLanguages' => $this->allAvailableLanguages,
             // If we have more then "all-languages" and 1 editors language available
             'moreThenOneLanguageAvailable' => count($this->allAvailableLanguages) > 2 ? true : false,
+            'languageAspect' => $this->languageAspect,
             'lllFile' => 'LLL:EXT:templavoilaplus/Resources/Private/Language/Backend/PageLayout.xlf',
             'userSettings' => TemplaVoilaUtility::getBackendUser()->uc['templavoilaplus'] ?? [],
             'is8orNewer' => version_compare(TYPO3_version, '8.0.0', '>=') ? true : false,
@@ -767,6 +773,8 @@ class PageLayoutController extends ActionController
             );
         }
         $this->currentLanguageKey = $this->allAvailableLanguages[$this->currentLanguageUid]['ISOcode'];
+
+        $this->languageAspect = TemplaVoilaUtility::fetchLanguageAspect($this->pageId, $this->currentLanguageUid);
     }
 
     /**


### PR DESCRIPTION
In order to cope for different l10n stuff it is important to sum up all info. This function provides a pseudo `languageAspect`, which is the core way to know the correct fallback for the currently selected language. As we focus on a single page additionally `pages.l18n_cfg` is added which can change the language mode per page. As this can create a lot of combinations, this introduction of an adapted `languageAspect` could work as single point of complexity.

This is to support functions for language views (e.g. only show translation with id 2 and not all) and could be either used
* while doing the output in fluid to simply filter the view, or
* while actually fetching localizations and localizationActions thus adding to the `sDEF`/`vDEF` complexity (which would be possible, but probably unnecessary)

It uses the 9LTS introduced `Context`/`LanguageAspect` architecture, but provides sane defaults for 8LTS (i.e. the recommendations of core mixed with the actual current implementation of `EXT:templavoilaplus`).