### PR TITLE
[BUGFIX] content edit modal title should accept HTML

### DIFF
--- a/Resources/Public/JavaScript/PageLayout.js
+++ b/Resources/Public/JavaScript/PageLayout.js
@@ -602,7 +602,7 @@ console.log('onAdd');
                   var iframeDocument = Modal.currentModal.find('.t3js-modal-iframe').get(0).contentDocument;
                     var form = iframeDocument.getElementById('EditDocumentController');
                     if (form) {
-                        Modal.currentModal.find('.t3js-modal-title').text(form.querySelector('h1').innerHTML);
+                        Modal.currentModal.find('.t3js-modal-title').html(form.querySelector('h1').innerHTML);
                         form.querySelector('h1').style.display = 'none';
                     }
                     var closeModal = iframeDocument.getElementById('CloseModal');


### PR DESCRIPTION
For short content headers just a string is used, however long content headers have <h1><span title="fulltitle">croppedtitle</span></h1> Thus in order to copy this to the modal title html needs to be used instead of text.

fixes #433 