### PR TITLE
[BUGFIX] FCEs with no mapping create exception

### DIFF
--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -326,7 +326,10 @@ class ProcessingService
             // Traverse the sheet's elements:
             if (is_array($sheetData) && is_array($sheetData['ROOT']['el'])) {
                 foreach ($lKeys as $lKey) {
-                    $childs[$sheetKey][$lKey] = $this->getNodeChildsFromElements($node, $sheetKey, $sheetData['ROOT']['el'], $lKey, $node['flexform']['data'][$sheetKey][$lKey], $basePid, $usedElements);
+                    // in seldom cases we could have no flexform data, e.g. if a FCE exists but has empty mapping
+                    if ($node['flexform']['data'][$sheetKey][$lKey] !== null) {
+                        $childs[$sheetKey][$lKey] = $this->getNodeChildsFromElements($node, $sheetKey, $sheetData['ROOT']['el'], $lKey, $node['flexform']['data'][$sheetKey][$lKey], $basePid, $usedElements);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Due to an error in a custom new content element wizard I created FCEs without a mapping set, this broke the page module with an exception:
`Core: Exception handler (WEB): Uncaught TYPO3 Exception: Argument 5 passed to Tvp\TemplaVoilaPlus\Service\ProcessingService::getNodeChildsFromElements() must be of the type array, null given, called in typo3conf/ext/templavoilaplus/Classes/Service/ProcessingService.php on line 329`

While it could be catched beforehand, this is actually the only thing that will raise an excetion in case of such broken CEs, so I propose an easy fix via IF.