### PR TITLE
[TASK] FCEs with no mapping error should be more visible

### DIFF
--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -155,7 +155,7 @@ class ProcessingService
             $usedElements[$table][$row['uid']]['count'] = 1;
         }
         $usedElements[$table][$row['uid']]['parentPointers'][] = $parentPointerString;
-
+        
         $node = [
             'raw' => [
                 'entity' => $row,
@@ -168,6 +168,7 @@ class ProcessingService
                 'description' => ($row[$GLOBALS['TCA'][$table]['ctrl']['descriptionColumn']] ?? ''),
                 'belongsToCurrentPage' => ($basePid === $onPid),
                 'countUsedOnPage' => $usedElements[$table][$row['uid']]['count'],
+                'errorNoMapping' => ($table === 'tt_content' && $row['CType'] === 'templavoilaplus_pi1' && !$row['tx_templavoilaplus_map']),
                 'parentPointer' => $parentPointerString,
                 'beLayout' => $combinedBackendLayoutConfigurationIdentifier,
                 'beLayoutDesign' => ($backendLayoutConfiguration ? $backendLayoutConfiguration->isDesign() : false),

--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node.html
@@ -16,6 +16,9 @@
     <a name="c{node.rendering.md5}{node.raw.entity.uid}"></a>
     <div class="card-header dragHandle">
         <f:render partial="Backend/Handler/DoktypeDefaultHandler/Node/TitleBar" arguments="{node: node}" />
+        <f:if condition="{node.rendering.errorNoMapping}">
+            <div class="bg-warning px-2 py-1">&nbsp;<em><core:icon identifier="status-dialog-error" /> <f:translate key="{settings.configuration.lllFile}:error.fce.noMapping" arguments="{0: node.rendering.countUsedOnPage}" /></em></div>
+        </f:if>
         <f:if condition="!{node.rendering.belongsToCurrentPage}">
             <div class="bg-info px-2 py-1">&nbsp;<em><core:icon identifier="status-dialog-notification" /> <f:translate key="{settings.configuration.lllFile}:infoElementFromOtherPage" arguments="{0: node.raw.entity.uid, 1: node.raw.entity.pid}" /></em></div>
         </f:if>


### PR DESCRIPTION
FCEs with no mapping offer no drop area obviously and the error message is just black in the preview area. Instead the same node-information-style like with "used multiple times on this page" should be used to be more coherent and make it more visible.
![y](https://user-images.githubusercontent.com/12411176/191714257-9e2d3bad-0987-4c7c-855f-fa05cb329559.png)
![z](https://user-images.githubusercontent.com/12411176/191714353-6fb04897-adc0-4ed6-a00d-f30e873d5f98.png)
