### PR TITLE
[BUGFIX] if node has same children multiple times it is not shown

### DIFF
--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -412,15 +412,13 @@ class ProcessingService
         // Note: key in $dbAnalysis->itemArray is not a valid counter! It is in 'tt_content_xx' format!
         $counter = 1;
         foreach ($dbAnalysis->itemArray as $position => $recIdent) {
-            $idStr = $table . ':' . $recIdent['id'];
-
             $contentRow = BackendUtility::getRecordWSOL($table, $recIdent['id']);
 
             $parentPointer['position'] = $position;
 
             // Only do it if the element referenced was not deleted! - or hidden :-)
             if (is_array($contentRow)) {
-                $nodes[$idStr] = $this->getNodeWithTree($table, $contentRow, $parentPointer, $basePid, $usedElements);
+                $nodes[] = $this->getNodeWithTree($table, $contentRow, $parentPointer, $basePid, $usedElements);
             }
         }
 


### PR DESCRIPTION
Child nodes are retrieved and added to an array via a key <table>:<uid>
However this prevents the same content from being added to a container multiple times, so currently a FCE container that has the same CE 2 times will only show one element in the backend. As the view is out of sync with the flex field adding/moving/etc elements into and out of that container will create race conditions.
As the key is not used anywhere, it is dropped in favor of basic numbering