### PR TITLE
[BUGFIX] Argument 2 passed to IconUtility::mapRecordTypeToIconIdentifier() must be of the type array, null given

### DIFF
--- a/Classes/Utility/IconUtility.php
+++ b/Classes/Utility/IconUtility.php
@@ -24,12 +24,13 @@ final class IconUtility
     public static function getRecordIconIdentifier($table, $uid, $fallbackIconIdentifier)
     {
         if (version_compare(TYPO3_version, '9.0.0', '>=')) {
-            $row = BackendUtility::getRecordWSOL($table, $uid);
-            $iconIdentifier = self::mapRecordTypeToIconIdentifier($table, $row);
-
             /** @var IconRegistry $iconRegistry */
             $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
             $defaultIcon = $iconRegistry->getDefaultIconIdentifier();
+
+            $row = BackendUtility::getRecordWSOL($table, $uid);
+            $iconIdentifier = is_array($row) ? self::mapRecordTypeToIconIdentifier($table, $row) : $defaultIcon;
+
             return $iconIdentifier === $defaultIcon ? $fallbackIconIdentifier : $iconIdentifier;
         } else {
             return $fallbackIconIdentifier;


### PR DESCRIPTION
In seldom conditions the original code is not robust enough. E.g. a page of type shortcut which had an content_from_pid set to a non existing page an exception would be raised, which would disable the whole page module for that page.