### PR TITLE
[FEATURE] add TSconfig additionalRecordData.<table> for BE node data attributes

### DIFF
--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -155,7 +155,18 @@ class ProcessingService
             $usedElements[$table][$row['uid']]['count'] = 1;
         }
         $usedElements[$table][$row['uid']]['parentPointers'][] = $parentPointerString;
-        
+
+        if ($parentPointer['table'] == 'pages') {
+            $pageTsConfig = BackendUtility::getPagesTSconfig($parentPointer['uid']);
+            $additionalRecordDataColumns = $pageTsConfig['mod.']['web_txtemplavoilaplusLayout.']['additionalRecordData.'][$table] ?? null;
+            if ($additionalRecordDataColumns) {
+                $additionalRecordData = ' ';
+                foreach (explode(',', $additionalRecordDataColumns) as $additionalRecordDataColumn) {
+                    $additionalRecordData .= 'data-' . strtolower($additionalRecordDataColumn) . '="' . ($row[$additionalRecordDataColumn] ?? '') . '" ';
+                }
+            }
+        }
+
         $node = [
             'raw' => [
                 'entity' => $row,
@@ -173,6 +184,7 @@ class ProcessingService
                 'beLayout' => $combinedBackendLayoutConfigurationIdentifier,
                 'beLayoutDesign' => ($backendLayoutConfiguration ? $backendLayoutConfiguration->isDesign() : false),
                 'md5' => md5($parentPointerString . '/' . $table . ':' . $row['uid']),
+                'additionalRecordData' => $additionalRecordData ?? ''
             ],
         ];
 

--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -156,7 +156,7 @@ class ProcessingService
         }
         $usedElements[$table][$row['uid']]['parentPointers'][] = $parentPointerString;
 
-        if ($parentPointer['table'] == 'pages') {
+        if ($parentPointer['table'] === 'pages') {
             $pageTsConfig = BackendUtility::getPagesTSconfig($parentPointer['uid']);
             $additionalRecordDataColumns = $pageTsConfig['mod.']['web_txtemplavoilaplusLayout.']['additionalRecordData.'][$table] ?? null;
             if ($additionalRecordDataColumns) {

--- a/Documentation/CreatingTemplateExtension/PageUserTsconfigReference/Index.rst
+++ b/Documentation/CreatingTemplateExtension/PageUserTsconfigReference/Index.rst
@@ -119,9 +119,6 @@ mod.web\_txtemplavoilaplusLayout
          fallback
 
 
-.. ###### END~OF~TABLE ######
-
-
 .. container:: table-row
 
    Property
@@ -145,6 +142,29 @@ mod.web\_txtemplavoilaplusLayout
 
          :typoscript:`mod.web_txtemplavoilaplusLayout.filterMaps.1 = vendor/yourextension/Page`
          :typoscript:`mod.web_txtemplavoilaplusLayout.filterMaps.2 = vendor/yourotherextension/FCE`
+
+   Default
+         null
+
+
+
+
+.. container:: table-row
+
+   Property
+         additionalRecordData
+
+   Data type
+         string/csv
+
+   Description
+         In order to add column values as data-attributes to backend preview nodes
+         for each table there can be a comma-separated list of columns which should
+         be output, e.g. to allow CSS based styling or custom JavaScript.
+
+         Examples:
+
+         :typoscript:`mod.web_txtemplavoilaplusLayout.additionalRecordData.tt_content = layout,imageorient`
 
    Default
          null

--- a/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node.html
+++ b/Resources/Private/Partials/Backend/Handler/DoktypeDefaultHandler/Node.html
@@ -12,7 +12,7 @@
 
 
 <f:section name="TableNode">
-<div class="tvp-node sortableItem {f:if(condition: '{settings.configuration.is10orNewer}', then:'', else: 'panel panel-default')} card {node.rendering.stylingClasses}" id="item{node.rendering.md5}" data-record-table="{node.raw.table}" data-record-uid="{node.raw.entity.uid}" data-parent-pointer="{node.rendering.parentPointer}">
+<div class="tvp-node sortableItem {f:if(condition: '{settings.configuration.is10orNewer}', then:'', else: 'panel panel-default')} card {node.rendering.stylingClasses}" id="item{node.rendering.md5}" data-record-table="{node.raw.table}" data-record-uid="{node.raw.entity.uid}" data-parent-pointer="{node.rendering.parentPointer}" {node.rendering.additionalRecordData -> f:format.raw()}>
     <a name="c{node.rendering.md5}{node.raw.entity.uid}"></a>
     <div class="card-header dragHandle">
         <f:render partial="Backend/Handler/DoktypeDefaultHandler/Node/TitleBar" arguments="{node: node}" />


### PR DESCRIPTION
It would be a benefit if like in TVP7 column values of nodes could have an inpact in BE preview rendering. In TVP7 this was hardcoded to `tt_content.layout` I propose to re-implement it and make it TSconfig configurable, e.g. use

`mod.web_txtemplavoilaplusLayout.additionalRecordData.tt_content = layout,imageorient`

to add `data-layout` and `data-imageorient` to a `tt_content` node in order to allow further custom CSS styling or custom JavaScript beyond the option for BackendLayouts.