### PR TITLE
[BUGFIX] page type external shows exception in BE page module

### DIFF
--- a/Classes/Controller/Backend/Handler/DoktypeLinkHandler.php
+++ b/Classes/Controller/Backend/Handler/DoktypeLinkHandler.php
@@ -44,7 +44,7 @@ class DoktypeLinkHandler
                 FlashMessage::INFO
             );
 
-            return $this->getLinkButton($controller, $pageRecord['url']);
+            return '';
         }
         return $this->handle8($controller, $pageRecord);
     }


### PR DESCRIPTION
fixes #446

In contrast to the other page types here is no button as buttons won't work with external URLs (no option for target _BLANK, X-Frame-Options prohibiting it in general.
The link can't be added to the FlashMessage either, as that doesn't allow HTML code.
Thus the URL is only shown in text as ist without a way to click it.