### PR TITLE
[BUGFIX] filterMaps and pageTSconfig wasn't respected in NewCeWizard

### DIFF
--- a/Classes/Controller/Backend/Ajax/ExtendedNewContentElementController.php
+++ b/Classes/Controller/Backend/Ajax/ExtendedNewContentElementController.php
@@ -48,4 +48,9 @@ class ExtendedNewContentElementController extends \TYPO3\CMS\Backend\Controller\
 
         return $wizardItems;
     }
+
+    public function getPageId()
+    {
+        return $this->id;
+    }
 }

--- a/Classes/Service/ItemsProcFunc.php
+++ b/Classes/Service/ItemsProcFunc.php
@@ -90,7 +90,7 @@ class ItemsProcFunc
      *
      * @return bool
      */
-    protected static function checkIfMapIsFiltered(array $tvpPageTsConfig, string $mappingPlace): bool
+    public static function checkIfMapIsFiltered(array $tvpPageTsConfig, string $mappingPlace): bool
     {
         if (isset($tvpPageTsConfig['filterMaps.'])) {
             $allowedPlaces = $tvpPageTsConfig['filterMaps.'];


### PR DESCRIPTION
#339 introduce map filtering, that was respected in TCA/TCEForm quite fine, but the newCeWizard tab FCE doesn't respect it. Additionally the old option to use
`mod.wizards.newContentElement.wizardItems.fce.show = *` or
`mod.wizards.newContentElement.wizardItems.fce.show = fce_<identifierA>,fce_<identifierB>` was missing to slim the entries in the tab to have any control on this.

This would again allow to hide the tab completely, e.g. via
`mod.wizards.newContentElement.wizardItems.fce.show = none` (as 'none' is a non-existing element) in order to use custom wizards on your own