### PR TITLE
[BUGFIX] clipboard copy to empty area broken

### DIFF
--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -623,7 +623,7 @@ class ProcessingService
     public function copyElement(string $destinationPointerString, string $sourceElementTable, int $sourceElementUid)
     {
         // Check and get all information about the source position:
-        $destinationPointer = $this->getValidPointer($destinationPointerString);
+        $destinationPointer = $this->getValidPointer($destinationPointerString, true);
         if (!$destinationPointer) {
             return false;
         }


### PR DESCRIPTION
destinationPointer is deemed invalid because empty, thus allowNew needs to be true