### PR TITLE
[TASK] add notification API and provide meaningful error messages (for clipboard actions)

### DIFF
--- a/Classes/Exception/ProcessingException.php
+++ b/Classes/Exception/ProcessingException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tvp\TemplaVoilaPlus\Exception;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * An exception which represents an error in the DataStructure.
+ */
+class ProcessingException extends \TYPO3\CMS\Core\Exception
+{
+}

--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -18,6 +18,7 @@ namespace Tvp\TemplaVoilaPlus\Service;
  */
 
 use Tvp\TemplaVoilaPlus\Domain\Model\Configuration\MappingConfiguration;
+use Tvp\TemplaVoilaPlus\Exception\ProcessingException;
 use Tvp\TemplaVoilaPlus\Exception\ConfigurationException;
 use Tvp\TemplaVoilaPlus\Exception\InvalidIdentifierException;
 use Tvp\TemplaVoilaPlus\Exception\MissingPlacesException;
@@ -625,11 +626,11 @@ class ProcessingService
         // Check and get all information about the source position:
         $destinationPointer = $this->getValidPointer($destinationPointerString);
         if (!$destinationPointer) {
-            return false;
+           throw new ProcessingException('Copy action has missing or invalid destinationPointer:'.$destinationPointerString);
         }
         // Only tt_content yet
         if ($sourceElementTable !== 'tt_content') {
-            return false;
+            throw new ProcessingException('Copy action only implemented for content elements');
         }
 
         $destinationRecord = $destinationPointer['foundRecord'];

--- a/Resources/Private/Templates/Backend/PageLayout/Show.html
+++ b/Resources/Private/Templates/Backend/PageLayout/Show.html
@@ -7,6 +7,7 @@
             includeRequireJsModules="{
         PageLayout: 'TYPO3/CMS/Templavoilaplus/PageLayout',
         Modal:'TYPO3/CMS/Backend/Modal',
+        Notification:'TYPO3/CMS/Backend/Notification',
         ContextMenu:'TYPO3/CMS/Backend/ContextMenu',
         Tooltip: 'TYPO3/CMS/Backend/Tooltip'
     }"
@@ -27,6 +28,7 @@
             includeRequireJsModules="{
         PageLayout: 'TYPO3/CMS/Templavoilaplus/PageLayout',
         Modal:'TYPO3/CMS/Backend/Modal',
+        Notification:'TYPO3/CMS/Backend/Notification',
         ContextMenu:'TYPO3/CMS/Backend/ContextMenu',
         Tooltip: 'TYPO3/CMS/Backend/Tooltip'
     }"

--- a/Resources/Public/JavaScript/PageLayout.js
+++ b/Resources/Public/JavaScript/PageLayout.js
@@ -194,7 +194,10 @@ console.log('onAdd');
                                     error: function(XMLHttpRequest, textStatus, errorThrown) {
                                         var el = evt.item;
                                         el.parentNode.removeChild(el);
-                                    }
+                                        require(['TYPO3/CMS/Backend/Notification'], function(Notification) {
+                                          Notification.error('Templavoilà! Plus Error', XMLHttpRequest.responseJSON.error);
+                                        });
+                                    },
                                 });
                                 break;
                             case 'trash':


### PR DESCRIPTION
While working on #453 I stumbled over errors being just returned as "400: false". 
I propose adding TYPO3 Notification api (available since 8LTS) to have instant-flashmessages in the top right corner, which allow to show an error message instead of silently failing in the browser console.

![Bildschirmfoto 2022-10-14 um 23 18 33](https://user-images.githubusercontent.com/12411176/195948372-d2c5c93c-be30-4470-91da-3a5599a52199.png)
 (Screenshot with bad spelling, fixed later, forgot to make new screenshot)
 
 This should probably be helpful for all ajax actions, but I rather wanted to propose this first before rehauling everything.