### PR TITLE
[BUGFIX] newly added Nodes are missing handlers

### DIFF
--- a/Classes/Controller/Backend/Ajax/AbstractResponse.php
+++ b/Classes/Controller/Backend/Ajax/AbstractResponse.php
@@ -49,13 +49,16 @@ abstract class AbstractResponse
         return $view;
     }
 
-    protected function record2html(string $table, int $uid): string
+    protected function record2html(string $table, int $uid, string $parentPointer = null): string
     {
         $row = BackendUtility::getRecord($table, $uid);
 
         /** @var ProcessingService */
         $processingService = GeneralUtility::makeInstance(ProcessingService::class);
         $nodeTree = $processingService->getNodeWithTree($table, $row);
+        if ($parentPointer) {
+            $nodeTree['node']['rendering']['parentPointer'] = $parentPointer;
+        }
 
         $view = $this->getFluidTemplateObject('EXT:templavoilaplus/Resources/Private/Templates/Backend/Ajax/InsertNode.html', $this->getSettings());
         $view->assign('nodeTree', $nodeTree);

--- a/Classes/Controller/Backend/Ajax/ContentElements.php
+++ b/Classes/Controller/Backend/Ajax/ContentElements.php
@@ -48,7 +48,7 @@ class ContentElements extends AbstractResponse
         if ($result) {
             return new JsonResponse([
                 'uid' => $result,
-                'nodeHtml' => $this->record2html('tt_content', $result),
+                'nodeHtml' => $this->record2html('tt_content', $result, $parameters['destinationPointer']),
             ]);
         } else {
             return new JsonResponse(

--- a/Resources/Public/JavaScript/PageLayout.js
+++ b/Resources/Public/JavaScript/PageLayout.js
@@ -65,7 +65,7 @@ define([
         var allDropzones = [].slice.call(document.querySelectorAll('.tvjs-dropzone'))
 
         for (var i = 0; i < allDropzones.length; i++) {
-            PageLayout.initSortable(allDropzones[i]);
+            PageLayout.initSortable(document);
         }
 
         new Sortable(document.getElementById('navbarTrash'), {
@@ -114,188 +114,49 @@ define([
         $('#moduleShadowing').addClass('hidden');
 
         PageLayout.addTooltipster();
-        PageLayout.initEditRecordListener(document);
-        PageLayout.initClipboardAddListener(document);
-        PageLayout.initSwitchVisibilityListener(document);
+        PageLayout.initElements(document);
         PageLayout.disableEmptyClipboard();
         PageLayout.disableEmptyTrash();
     }
 
-    PageLayout.initSortable = function(el) {
-      new Sortable(el, {
-        revertOnSpill: true,
-        group: {
-          name: 'dropzones_' + el.dataset.childAllowed,
-          pull: function (to, from, el, evt) {
-            if (to.el.id === 'navbarClipboard') {
-              return 'clone';
-            }
-            if (to.el.id === 'navbarTrash') {
+
+    PageLayout.initElements = function (base) {
+        PageLayout.initSortable(base);
+        PageLayout.initEditRecordListener(base);
+        PageLayout.initClipboardAddListener(base);
+        PageLayout.initSwitchVisibilityListener(base);
+    }
+
+    PageLayout.initSortable = function (base) {
+      var allItems = base.querySelectorAll('.tvjs-dropzone');
+      for (const el of allItems) {
+        new Sortable(el, {
+          revertOnSpill: true,
+          group: {
+            name: 'dropzones_' + el.dataset.childAllowed,
+            pull: function (to, from, el, evt) {
+              if (to.el.id === 'navbarClipboard') {
+                return 'clone';
+              }
+              if (to.el.id === 'navbarTrash') {
+                return true;
+              }
               return true;
-            }
-            return true;
-          },
-          put: function (to, from, el, evt) {
-//                         console.log(el);
-//                         $(to.el).addClass('green');
-          },
-          revertClone: true
-        },
-        ghostClass: "iAmGhost",
-        dragable: '.sortableItem',
-        animation: 150,
-        swapThreshold: 0.65,
-        emptyInsertThreshold: 30,
-        onUpdate: function (/**Event*/evt) {
-          console.log('onUpdate');
-          // Move inside field
-          PageLayout.showInProgress(evt.item);
-          $.ajax({
-            type: 'POST',
-            data: {
-              sourcePointer: evt.from.dataset.parentPointer + ':' + evt.oldDraggableIndex.toString(),
-              destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString()
             },
-            url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_move'],
-            success: function(data) {
-              // @TODO Elements need to update their parenPointer after move
-              PageLayout.showSuccess(evt.item);
+            put: function (to, from, el, evt) {
+              // console.log(el);
+              // $(to.el).addClass('green');
             },
-            error: function(XMLHttpRequest, textStatus, errorThrown) {
-              PageLayout.showError(evt.item);
-              return false;
-            }
-          });
-        },
-        onSort: function (/**Event*/evt) {
-          console.log('onSort');
-        },
-        onRemove: function (/**Event*/evt) {
-          console.log('onRemove');
-        },
-        onFilter: function (/**Event*/evt) {
-          console.log('onFilter');
-        },
-        onClone: function (/**Event*/evt) {
-          console.log('onClone');
-        },
-        onChange: function (/**Event*/evt) {
-          console.log('onChange');
-        },
-        onStart: function (/**Event*/evt) {
-          console.log('onStart');
-          $('#navbarClipboard').removeClass('disabled');
-          $('#navbarTrash').removeClass('disabled');
-        },
-        onEnd: function (/**Event*/evt) {
-          console.log('onEnd');
-          PageLayout.disableEmptyClipboard();
-          PageLayout.disableEmptyTrash();
-          $(evt.item).removeClass('blue');
-        },
-        onMove: function (/**Event*/evt, /**Event*/originalEvent) {
-          console.log('onMove');
-          $('.iAmGhost').addClass('blue');
-        },
-        onAdd: function (/**Event*/evt) {
-          console.log('onAdd');
-          if (evt.pullMode === 'clone') {
-            // Insert from NewContentElementWizard (later also clipboard/trash)
-            switch (evt.item.dataset.panel) {
-              case 'newcontent':
-                // source/destination pages:694:sDEF:lDEF:field_breitOben:vDEF:1
-                $.ajax({
-                  type: 'POST',
-                  data: {
-                    destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
-                    elementRow: JSON.parse(evt.item.dataset.elementRow)
-                  },
-                  url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_create'],
-                  success: function(data) {
-                    var div = document.createElement('div');
-                    div.innerHTML = data.nodeHtml;
-                    PageLayout.initEditRecordListener(div.firstElementChild);
-                    PageLayout.initSwitchVisibilityListener(div.firstElementChild);
-                    PageLayout.showSuccess(div.firstElementChild);
-                    evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
-                    // reinit dropzones because element could be FCE
-                    var allDropzones = [].slice.call(document.querySelectorAll('.tvjs-dropzone'))
-
-                    for (var i = 0; i < allDropzones.length; i++) {
-                      PageLayout.initSortable(allDropzones[i]);
-                    }
-                  },
-                  error: function(XMLHttpRequest, textStatus, errorThrown) {
-                    var el = evt.item;
-                    el.parentNode.removeChild(el);
-                  }
-                });
-                break;
-              case 'clipboard':
-                // Check clipboard mode copy/move/reference
-                // Non tt_content can only be referenced (if target allows them!
-                var mode = evt.from.parentNode.querySelector('input[name="clipboardMode"]:checked').value;
-                $.ajax({
-                  type: 'POST',
-                  data: {
-                    destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
-                    mode: mode,
-                    sourceTable: evt.item.dataset.recordTable,
-                    sourceUid: evt.item.dataset.recordUid
-                  },
-                  url: TYPO3.settings.ajaxUrls['templavoilaplus_clipboard_action'],
-                  success: function(data) {
-                    var div = document.createElement('div');
-                    div.innerHTML = data.nodeHtml;
-                    PageLayout.initEditRecordListener(div.firstElementChild);
-                    PageLayout.initSwitchVisibilityListener(div.firstElementChild);
-                    PageLayout.showSuccess(div.firstElementChild);
-                    evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
-
-                    PageLayout.updateClipboardNumber(data.clipboard);
-                  },
-                  error: function(XMLHttpRequest, textStatus, errorThrown) {
-                    var el = evt.item;
-                    el.parentNode.removeChild(el);
-                    require(['TYPO3/CMS/Backend/Notification'], function(Notification) {
-                      Notification.error('Templavoilà! Plus Error', XMLHttpRequest.responseJSON.error);
-                    });
-                  },
-                });
-                break;
-              case 'trash':
-                console.log(evt.item, evt.target);
-                $.ajax({
-                  type: 'POST',
-                  data: {
-                    destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
-                    sourceTable: evt.item.dataset.recordTable,
-                    sourceUid: evt.item.dataset.recordUid,
-                    pid: $('#moduleWrapper').data('tvpPageId')
-                  },
-                  url: TYPO3.settings.ajaxUrls['templavoilaplus_trash_link'],
-                  success: function(data) {
-                    var div = document.createElement('div');
-                    div.innerHTML = data.nodeHtml;
-                    PageLayout.initEditRecordListener(div.firstElementChild);
-                    PageLayout.initSwitchVisibilityListener(div.firstElementChild);
-                    PageLayout.showSuccess(div.firstElementChild);
-                    evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
-                    PageLayout.updateTrashNumber(data.trash);
-                  },
-                  error: function(XMLHttpRequest, textStatus, errorThrown) {
-                    var el = evt.item;
-                    el.parentNode.removeChild(el);
-                  }
-                });
-                return false;
-                break;
-              default:
-                return false;
-            }
-          } else {
-            // Move from another field
-            // source/destination pages:694:sDEF:lDEF:field_breitOben:vDEF:1
+            revertClone: true
+          },
+          ghostClass: "iAmGhost",
+          dragable: '.sortableItem',
+          animation: 150,
+          swapThreshold: 0.65,
+          emptyInsertThreshold: 30,
+          onUpdate: function (/**Event*/evt) {
+            console.log('onUpdate');
+            // Move inside field
             PageLayout.showInProgress(evt.item);
             $.ajax({
               type: 'POST',
@@ -304,17 +165,156 @@ define([
                 destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString()
               },
               url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_move'],
-              success: function(data) {
+              success: function (data) {
                 // @TODO Elements need to update their parenPointer after move
                 PageLayout.showSuccess(evt.item);
               },
-              error: function(XMLHttpRequest, textStatus, errorThrown) {
+              error: function (XMLHttpRequest, textStatus, errorThrown) {
                 PageLayout.showError(evt.item);
+                return false;
               }
             });
+          },
+          onSort: function (/**Event*/evt) {
+            console.log('onSort');
+          },
+          onRemove: function (/**Event*/evt) {
+            console.log('onRemove');
+          },
+          onFilter: function (/**Event*/evt) {
+            console.log('onFilter');
+          },
+          onClone: function (/**Event*/evt) {
+            console.log('onClone');
+          },
+          onChange: function (/**Event*/evt) {
+            console.log('onChange');
+          },
+          onStart: function (/**Event*/evt) {
+            console.log('onStart');
+            $('#navbarClipboard').removeClass('disabled');
+            $('#navbarTrash').removeClass('disabled');
+          },
+          onEnd: function (/**Event*/evt) {
+            console.log('onEnd');
+            PageLayout.disableEmptyClipboard();
+            PageLayout.disableEmptyTrash();
+            $(evt.item).removeClass('blue');
+          },
+          onMove: function (/**Event*/evt, /**Event*/originalEvent) {
+            console.log('onMove');
+            $('.iAmGhost').addClass('blue');
+          },
+          onAdd: function (/**Event*/evt) {
+            console.log('onAdd');
+            if (evt.pullMode === 'clone') {
+              // Insert from NewContentElementWizard (later also clipboard/trash)
+              switch (evt.item.dataset.panel) {
+                case 'newcontent':
+                  // source/destination pages:694:sDEF:lDEF:field_breitOben:vDEF:1
+                  $.ajax({
+                    type: 'POST',
+                    data: {
+                      destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
+                      elementRow: JSON.parse(evt.item.dataset.elementRow)
+                    },
+                    url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_create'],
+                    success: function (data) {
+                      var div = document.createElement('div');
+                      div.innerHTML = data.nodeHtml;
+                      PageLayout.initElements(div.firstElementChild);
+                      PageLayout.showSuccess(div.firstElementChild);
+                      evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
+                    },
+                    error: function (XMLHttpRequest, textStatus, errorThrown) {
+                      var el = evt.item;
+                      el.parentNode.removeChild(el);
+                    }
+                  });
+                  break;
+                case 'clipboard':
+                  // Check clipboard mode copy/move/reference
+                  // Non tt_content can only be referenced (if target allows them!
+                  var mode = evt.from.parentNode.querySelector('input[name="clipboardMode"]:checked').value;
+                  $.ajax({
+                    type: 'POST',
+                    data: {
+                      destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
+                      mode: mode,
+                      sourceTable: evt.item.dataset.recordTable,
+                      sourceUid: evt.item.dataset.recordUid
+                    },
+                    url: TYPO3.settings.ajaxUrls['templavoilaplus_clipboard_action'],
+                    success: function (data) {
+                      var div = document.createElement('div');
+                      div.innerHTML = data.nodeHtml;
+                      PageLayout.initElements(div.firstElementChild);
+                      PageLayout.showSuccess(div.firstElementChild);
+                      evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
+
+                      PageLayout.updateClipboardNumber(data.clipboard);
+                    },
+                    error: function (XMLHttpRequest, textStatus, errorThrown) {
+                      var el = evt.item;
+                      el.parentNode.removeChild(el);
+                      require(['TYPO3/CMS/Backend/Notification'], function (Notification) {
+                        Notification.error('Templavoilà! Plus Error', XMLHttpRequest.responseJSON.error);
+                      });
+                    },
+                  });
+                  break;
+                case 'trash':
+                  console.log(evt.item, evt.target);
+                  $.ajax({
+                    type: 'POST',
+                    data: {
+                      destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
+                      sourceTable: evt.item.dataset.recordTable,
+                      sourceUid: evt.item.dataset.recordUid,
+                      pid: $('#moduleWrapper').data('tvpPageId')
+                    },
+                    url: TYPO3.settings.ajaxUrls['templavoilaplus_trash_link'],
+                    success: function (data) {
+                      var div = document.createElement('div');
+                      div.innerHTML = data.nodeHtml;
+                      PageLayout.initElements(div.firstElementChild);
+                      PageLayout.showSuccess(div.firstElementChild);
+                      evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
+                      PageLayout.updateTrashNumber(data.trash);
+                    },
+                    error: function (XMLHttpRequest, textStatus, errorThrown) {
+                      var el = evt.item;
+                      el.parentNode.removeChild(el);
+                    }
+                  });
+                  return false;
+                  break;
+                default:
+                  return false;
+              }
+            } else {
+              // Move from another field
+              // source/destination pages:694:sDEF:lDEF:field_breitOben:vDEF:1
+              PageLayout.showInProgress(evt.item);
+              $.ajax({
+                type: 'POST',
+                data: {
+                  sourcePointer: evt.from.dataset.parentPointer + ':' + evt.oldDraggableIndex.toString(),
+                  destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString()
+                },
+                url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_move'],
+                success: function (data) {
+                  // @TODO Elements need to update their parenPointer after move
+                  PageLayout.showSuccess(evt.item);
+                },
+                error: function (XMLHttpRequest, textStatus, errorThrown) {
+                  PageLayout.showError(evt.item);
+                }
+              });
+            }
           }
-        }
-      });
+        });
+      }
     }
 
     PageLayout.addTooltipster = function() {
@@ -719,8 +719,7 @@ define([
                 div.innerHTML = data.nodeHtml;
                 for (var item of items) {
                     var newItem = div.firstElementChild.cloneNode(true)
-                    PageLayout.initEditRecordListener(newItem);
-                    PageLayout.initSwitchVisibilityListener(newItem);
+                    PageLayout.initElements(newItem);
                     PageLayout.showSuccess(newItem);
                     item.parentNode.replaceChild(newItem, item);
                 }

--- a/Resources/Public/JavaScript/PageLayout.js
+++ b/Resources/Public/JavaScript/PageLayout.js
@@ -65,193 +65,7 @@ define([
         var allDropzones = [].slice.call(document.querySelectorAll('.tvjs-dropzone'))
 
         for (var i = 0; i < allDropzones.length; i++) {
-            new Sortable(allDropzones[i], {
-                revertOnSpill: true,
-                group: {
-                    name: 'dropzones_' + allDropzones[i].dataset.childAllowed,
-                    pull: function (to, from, el, evt) {
-                        if (to.el.id === 'navbarClipboard') {
-                            return 'clone';
-                        }
-                        if (to.el.id === 'navbarTrash') {
-                            return true;
-                        }
-                        return true;
-                    },
-                    put: function (to, from, el, evt) {
-//                         console.log(el);
-//                         $(to.el).addClass('green');
-                    },
-                    revertClone: true
-                },
-                ghostClass: "iAmGhost",
-                dragable: '.sortableItem',
-                animation: 150,
-                swapThreshold: 0.65,
-                emptyInsertThreshold: 30,
-                onUpdate: function (/**Event*/evt) {
-console.log('onUpdate');
-                    // Move inside field
-                    PageLayout.showInProgress(evt.item);
-                    $.ajax({
-                      type: 'POST',
-                      data: {
-                          sourcePointer: evt.from.dataset.parentPointer + ':' + evt.oldDraggableIndex.toString(),
-                          destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString()
-                      },
-                      url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_move'],
-                      success: function(data) {
-                          // @TODO Elements need to update their parenPointer after move
-                          PageLayout.showSuccess(evt.item);
-                      },
-                      error: function(XMLHttpRequest, textStatus, errorThrown) {
-                          PageLayout.showError(evt.item);
-                          return false;
-                      }
-                    });
-                },
-                onSort: function (/**Event*/evt) {
-console.log('onSort');
-                },
-                onRemove: function (/**Event*/evt) {
-console.log('onRemove');
-                },
-                onFilter: function (/**Event*/evt) {
-console.log('onFilter');
-                },
-                onClone: function (/**Event*/evt) {
-console.log('onClone');
-                },
-                onChange: function (/**Event*/evt) {
-console.log('onChange');
-                },
-                onStart: function (/**Event*/evt) {
-console.log('onStart');
-                    $('#navbarClipboard').removeClass('disabled');
-                    $('#navbarTrash').removeClass('disabled');
-                },
-                onEnd: function (/**Event*/evt) {
-console.log('onEnd');
-                    PageLayout.disableEmptyClipboard();
-                    PageLayout.disableEmptyTrash();
-                    $(evt.item).removeClass('blue');
-                },
-                onMove: function (/**Event*/evt, /**Event*/originalEvent) {
-console.log('onMove');
-                    $('.iAmGhost').addClass('blue');
-                },
-                onAdd: function (/**Event*/evt) {
-console.log('onAdd');
-                    if (evt.pullMode === 'clone') {
-                        // Insert from NewContentElementWizard (later also clipboard/trash)
-                        switch (evt.item.dataset.panel) {
-                            case 'newcontent':
-                                // source/destination pages:694:sDEF:lDEF:field_breitOben:vDEF:1
-                                $.ajax({
-                                    type: 'POST',
-                                    data: {
-                                        destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
-                                        elementRow: JSON.parse(evt.item.dataset.elementRow)
-                                    },
-                                    url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_create'],
-                                    success: function(data) {
-                                        var div = document.createElement('div');
-                                        div.innerHTML = data.nodeHtml;
-                                        PageLayout.initEditRecordListener(div.firstElementChild);
-                                        PageLayout.initSwitchVisibilityListener(div.firstElementChild);
-                                        PageLayout.showSuccess(div.firstElementChild);
-                                        evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
-                                    },
-                                    error: function(XMLHttpRequest, textStatus, errorThrown) {
-                                        var el = evt.item;
-                                        el.parentNode.removeChild(el);
-                                    }
-                                });
-                                break;
-                            case 'clipboard':
-                                // Check clipboard mode copy/move/reference
-                                // Non tt_content can only be referenced (if target allows them!
-                                var mode = evt.from.parentNode.querySelector('input[name="clipboardMode"]:checked').value;
-                                $.ajax({
-                                    type: 'POST',
-                                    data: {
-                                        destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
-                                        mode: mode,
-                                        sourceTable: evt.item.dataset.recordTable,
-                                        sourceUid: evt.item.dataset.recordUid
-                                    },
-                                    url: TYPO3.settings.ajaxUrls['templavoilaplus_clipboard_action'],
-                                    success: function(data) {
-                                        var div = document.createElement('div');
-                                        div.innerHTML = data.nodeHtml;
-                                        PageLayout.initEditRecordListener(div.firstElementChild);
-                                        PageLayout.initSwitchVisibilityListener(div.firstElementChild);
-                                        PageLayout.showSuccess(div.firstElementChild);
-                                        evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
-
-                                        PageLayout.updateClipboardNumber(data.clipboard);
-                                    },
-                                    error: function(XMLHttpRequest, textStatus, errorThrown) {
-                                        var el = evt.item;
-                                        el.parentNode.removeChild(el);
-                                        require(['TYPO3/CMS/Backend/Notification'], function(Notification) {
-                                          Notification.error('Templavoilà! Plus Error', XMLHttpRequest.responseJSON.error);
-                                        });
-                                    },
-                                });
-                                break;
-                            case 'trash':
-                                console.log(evt.item, evt.target);
-                                $.ajax({
-                                    type: 'POST',
-                                    data: {
-                                        destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
-                                        sourceTable: evt.item.dataset.recordTable,
-                                        sourceUid: evt.item.dataset.recordUid,
-                                        pid: $('#moduleWrapper').data('tvpPageId')
-                                    },
-                                    url: TYPO3.settings.ajaxUrls['templavoilaplus_trash_link'],
-                                    success: function(data) {
-                                        var div = document.createElement('div');
-                                        div.innerHTML = data.nodeHtml;
-                                        PageLayout.initEditRecordListener(div.firstElementChild);
-                                        PageLayout.initSwitchVisibilityListener(div.firstElementChild);
-                                        PageLayout.showSuccess(div.firstElementChild);
-                                        evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
-                                       PageLayout.updateTrashNumber(data.trash);
-                                    },
-                                    error: function(XMLHttpRequest, textStatus, errorThrown) {
-                                        var el = evt.item;
-                                        el.parentNode.removeChild(el);
-                                    }
-                                });
-                                return false;
-                                break;
-                            default:
-                                return false;
-                        }
-                    } else {
-                        // Move from another field
-                        // source/destination pages:694:sDEF:lDEF:field_breitOben:vDEF:1
-                        PageLayout.showInProgress(evt.item);
-                        $.ajax({
-                            type: 'POST',
-                            data: {
-                                sourcePointer: evt.from.dataset.parentPointer + ':' + evt.oldDraggableIndex.toString(),
-                                destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString()
-                            },
-                            url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_move'],
-                            success: function(data) {
-                                // @TODO Elements need to update their parenPointer after move
-                                PageLayout.showSuccess(evt.item);
-                            },
-                            error: function(XMLHttpRequest, textStatus, errorThrown) {
-                                PageLayout.showError(evt.item);
-                            }
-                        });
-                    }
-                }
-            });
+            PageLayout.initSortable(allDropzones[i]);
         }
 
         new Sortable(document.getElementById('navbarTrash'), {
@@ -305,6 +119,202 @@ console.log('onAdd');
         PageLayout.initSwitchVisibilityListener(document);
         PageLayout.disableEmptyClipboard();
         PageLayout.disableEmptyTrash();
+    }
+
+    PageLayout.initSortable = function(el) {
+      new Sortable(el, {
+        revertOnSpill: true,
+        group: {
+          name: 'dropzones_' + el.dataset.childAllowed,
+          pull: function (to, from, el, evt) {
+            if (to.el.id === 'navbarClipboard') {
+              return 'clone';
+            }
+            if (to.el.id === 'navbarTrash') {
+              return true;
+            }
+            return true;
+          },
+          put: function (to, from, el, evt) {
+//                         console.log(el);
+//                         $(to.el).addClass('green');
+          },
+          revertClone: true
+        },
+        ghostClass: "iAmGhost",
+        dragable: '.sortableItem',
+        animation: 150,
+        swapThreshold: 0.65,
+        emptyInsertThreshold: 30,
+        onUpdate: function (/**Event*/evt) {
+          console.log('onUpdate');
+          // Move inside field
+          PageLayout.showInProgress(evt.item);
+          $.ajax({
+            type: 'POST',
+            data: {
+              sourcePointer: evt.from.dataset.parentPointer + ':' + evt.oldDraggableIndex.toString(),
+              destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString()
+            },
+            url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_move'],
+            success: function(data) {
+              // @TODO Elements need to update their parenPointer after move
+              PageLayout.showSuccess(evt.item);
+            },
+            error: function(XMLHttpRequest, textStatus, errorThrown) {
+              PageLayout.showError(evt.item);
+              return false;
+            }
+          });
+        },
+        onSort: function (/**Event*/evt) {
+          console.log('onSort');
+        },
+        onRemove: function (/**Event*/evt) {
+          console.log('onRemove');
+        },
+        onFilter: function (/**Event*/evt) {
+          console.log('onFilter');
+        },
+        onClone: function (/**Event*/evt) {
+          console.log('onClone');
+        },
+        onChange: function (/**Event*/evt) {
+          console.log('onChange');
+        },
+        onStart: function (/**Event*/evt) {
+          console.log('onStart');
+          $('#navbarClipboard').removeClass('disabled');
+          $('#navbarTrash').removeClass('disabled');
+        },
+        onEnd: function (/**Event*/evt) {
+          console.log('onEnd');
+          PageLayout.disableEmptyClipboard();
+          PageLayout.disableEmptyTrash();
+          $(evt.item).removeClass('blue');
+        },
+        onMove: function (/**Event*/evt, /**Event*/originalEvent) {
+          console.log('onMove');
+          $('.iAmGhost').addClass('blue');
+        },
+        onAdd: function (/**Event*/evt) {
+          console.log('onAdd');
+          if (evt.pullMode === 'clone') {
+            // Insert from NewContentElementWizard (later also clipboard/trash)
+            switch (evt.item.dataset.panel) {
+              case 'newcontent':
+                // source/destination pages:694:sDEF:lDEF:field_breitOben:vDEF:1
+                $.ajax({
+                  type: 'POST',
+                  data: {
+                    destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
+                    elementRow: JSON.parse(evt.item.dataset.elementRow)
+                  },
+                  url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_create'],
+                  success: function(data) {
+                    var div = document.createElement('div');
+                    div.innerHTML = data.nodeHtml;
+                    PageLayout.initEditRecordListener(div.firstElementChild);
+                    PageLayout.initSwitchVisibilityListener(div.firstElementChild);
+                    PageLayout.showSuccess(div.firstElementChild);
+                    evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
+                    // reinit dropzones because element could be FCE
+                    var allDropzones = [].slice.call(document.querySelectorAll('.tvjs-dropzone'))
+
+                    for (var i = 0; i < allDropzones.length; i++) {
+                      PageLayout.initSortable(allDropzones[i]);
+                    }
+                  },
+                  error: function(XMLHttpRequest, textStatus, errorThrown) {
+                    var el = evt.item;
+                    el.parentNode.removeChild(el);
+                  }
+                });
+                break;
+              case 'clipboard':
+                // Check clipboard mode copy/move/reference
+                // Non tt_content can only be referenced (if target allows them!
+                var mode = evt.from.parentNode.querySelector('input[name="clipboardMode"]:checked').value;
+                $.ajax({
+                  type: 'POST',
+                  data: {
+                    destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
+                    mode: mode,
+                    sourceTable: evt.item.dataset.recordTable,
+                    sourceUid: evt.item.dataset.recordUid
+                  },
+                  url: TYPO3.settings.ajaxUrls['templavoilaplus_clipboard_action'],
+                  success: function(data) {
+                    var div = document.createElement('div');
+                    div.innerHTML = data.nodeHtml;
+                    PageLayout.initEditRecordListener(div.firstElementChild);
+                    PageLayout.initSwitchVisibilityListener(div.firstElementChild);
+                    PageLayout.showSuccess(div.firstElementChild);
+                    evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
+
+                    PageLayout.updateClipboardNumber(data.clipboard);
+                  },
+                  error: function(XMLHttpRequest, textStatus, errorThrown) {
+                    var el = evt.item;
+                    el.parentNode.removeChild(el);
+                    require(['TYPO3/CMS/Backend/Notification'], function(Notification) {
+                      Notification.error('Templavoilà! Plus Error', XMLHttpRequest.responseJSON.error);
+                    });
+                  },
+                });
+                break;
+              case 'trash':
+                console.log(evt.item, evt.target);
+                $.ajax({
+                  type: 'POST',
+                  data: {
+                    destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString(),
+                    sourceTable: evt.item.dataset.recordTable,
+                    sourceUid: evt.item.dataset.recordUid,
+                    pid: $('#moduleWrapper').data('tvpPageId')
+                  },
+                  url: TYPO3.settings.ajaxUrls['templavoilaplus_trash_link'],
+                  success: function(data) {
+                    var div = document.createElement('div');
+                    div.innerHTML = data.nodeHtml;
+                    PageLayout.initEditRecordListener(div.firstElementChild);
+                    PageLayout.initSwitchVisibilityListener(div.firstElementChild);
+                    PageLayout.showSuccess(div.firstElementChild);
+                    evt.item.parentNode.replaceChild(div.firstElementChild, evt.item);
+                    PageLayout.updateTrashNumber(data.trash);
+                  },
+                  error: function(XMLHttpRequest, textStatus, errorThrown) {
+                    var el = evt.item;
+                    el.parentNode.removeChild(el);
+                  }
+                });
+                return false;
+                break;
+              default:
+                return false;
+            }
+          } else {
+            // Move from another field
+            // source/destination pages:694:sDEF:lDEF:field_breitOben:vDEF:1
+            PageLayout.showInProgress(evt.item);
+            $.ajax({
+              type: 'POST',
+              data: {
+                sourcePointer: evt.from.dataset.parentPointer + ':' + evt.oldDraggableIndex.toString(),
+                destinationPointer: evt.target.dataset.parentPointer + ':' + evt.newDraggableIndex.toString()
+              },
+              url: TYPO3.settings.ajaxUrls['templavoilaplus_contentElement_move'],
+              success: function(data) {
+                // @TODO Elements need to update their parenPointer after move
+                PageLayout.showSuccess(evt.item);
+              },
+              error: function(XMLHttpRequest, textStatus, errorThrown) {
+                PageLayout.showError(evt.item);
+              }
+            });
+          }
+        }
+      });
     }
 
     PageLayout.addTooltipster = function() {


### PR DESCRIPTION
adding a new FCE doesn't activate its dropzone, as the ajax-provided HTML code is showing a wrong data-parent-pointer and because the javascript events aren't registered

Addition, see https://github.com/T3Voila/templavoilaplus/pull/455#issuecomment-1281954544: clipboard wasn't working either on new nodes