### PR TITLE
[BUGFIX] newCEwizard hook expects ExtendedNewContentElementController

### DIFF
--- a/Classes/Hooks/WizardItems.php
+++ b/Classes/Hooks/WizardItems.php
@@ -2,6 +2,7 @@
 
 namespace Tvp\TemplaVoilaPlus\Hooks;
 
+use Tvp\TemplaVoilaPlus\Controller\Backend\Ajax\ExtendedNewContentElementController;
 use Tvp\TemplaVoilaPlus\Service\ConfigurationService;
 use Tvp\TemplaVoilaPlus\Service\ItemsProcFunc;
 use Tvp\TemplaVoilaPlus\Utility\TemplaVoilaUtility;
@@ -43,15 +44,24 @@ class WizardItems implements NewContentElementWizardHookInterface
                 foreach ($mappingConfigurations as $mappingConfiguration) {
                     $combinedMappingIdentifier = $mappingPlace->getIdentifier() . ':' . $mappingConfiguration->getIdentifier();
                     $wizardLabel = 'fce_' . $combinedMappingIdentifier;
-                    if ($this->checkIfWizardItemShouldBeShown($parentObject->getPageId(), $combinedMappingIdentifier, $wizardLabel)) {
-                        $fceWizardItems['fce_' . $combinedMappingIdentifier] = [
-                            'iconIdentifier' => ($iconIdentifier ?: 'extensions-templavoila-template-default'),
-                            'description' => /** @TODO $mappingConfiguration->getDescription() ?? */
-                                TemplaVoilaUtility::getLanguageService()->getLL('template_nodescriptionavailable'),
-                            'title' => $mappingConfiguration->getName(),
-                            'params' => $this->getDataHandlerDefaultValues($combinedMappingIdentifier),
-                        ];
+
+                    if ($parentObject instanceof ExtendedNewContentElementController
+                            && !$this->checkIfWizardItemShouldBeShown(
+                                $parentObject->getPageId(),
+                                $combinedMappingIdentifier,
+                                $wizardLabel
+                            )
+                    ) {
+                        /* if TVP custom controller and should not be shown skip to next FCE */
+                        continue;
                     }
+                    $fceWizardItems['fce_' . $combinedMappingIdentifier] = [
+                        'iconIdentifier' => ($iconIdentifier ?: 'extensions-templavoila-template-default'),
+                        'description' => /** @TODO $mappingConfiguration->getDescription() ?? */
+                            TemplaVoilaUtility::getLanguageService()->getLL('template_nodescriptionavailable'),
+                        'title' => $mappingConfiguration->getName(),
+                        'params' => $this->getDataHandlerDefaultValues($combinedMappingIdentifier),
+                    ];
                 }
             }
         }


### PR DESCRIPTION
the newCEwizard hook expects ExtendedNewContentElementController to retrieve the page. This works if newCEwizard is called inside TVP, but not if its called in list module.

For the sake of not having a better fix, the whole filtering of FCEs is disabled in list module to prevent an exception up until a better fix is available.

exception for reference:
```
Tue, 25 Oct 2022 18:02:36 +0200 [CRITICAL] request="1b357f0bd48b5" 
component="TYPO3.CMS.Core.Error.ProductionExceptionHandler": 
Core: Exception handler (WEB: BE): Error, code #0, 
file /typo3conf/ext/templavoilaplus/Classes/Hooks/WizardItems.php, line 46: 
Call to undefined method TYPO3\CMS\Backend\Controller\ContentElement\NewContentElementController::getPageId()
```