### PR TITLE
[TASK] sidebar buttons need tooltip, icons shouldn't be draggable

### DIFF
--- a/Classes/ViewHelpers/ToolTipAttributesViewHelper.php
+++ b/Classes/ViewHelpers/ToolTipAttributesViewHelper.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvp\TemplaVoilaPlus\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * Calls BackendUtility::getItemLabel with given parameters
+ */
+class ToolTipAttributesViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * No output escaping as some tags may be allowed
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * Initialize ViewHelper arguments
+     *
+     * @throws \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('text', 'string', 'String to display', true);
+        $this->registerArgument('html', 'bool', 'HTML content', false, 'false');
+        $this->registerArgument('placement', 'string', 'left or right', false, 'right');
+    }
+
+    /**
+     * To ensure all tags are removed, child node's output must not be escaped
+     *
+     * @var bool
+     */
+    protected $escapeChildren = false;
+
+    /**
+     * Applies strip_tags() on the specified value.
+     *
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param \TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface $renderingContext
+     *
+     * @return string
+     * @see https://www.php.net/manual/function.strip-tags.php
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        if (version_compare(TYPO3_version, '11.0.0', '>=')) {
+            return sprintf(
+                'data-bs-title="%s" data-bs-toggle="tooltip" data-bs-placement="%s" data-bs-html="%s"',
+                $arguments['text'],
+                $arguments['placement'],
+                $arguments['html']
+            );
+        }
+        return sprintf(
+            'data-title="%s" data-toggle="tooltip" data-placement="%s" data-html="%s"',
+            $arguments['text'],
+            $arguments['placement'],
+            $arguments['html']
+        );
+    }
+}

--- a/Resources/Private/Language/Backend/PageLayout.xlf
+++ b/Resources/Private/Language/Backend/PageLayout.xlf
@@ -122,6 +122,9 @@
             </trans-unit>
 
 			<!-- sidebar -->
+			<trans-unit id="clipboardAriaLabel" xml:space="preserve">
+				<source>You can drag items from the page to add them to the clipboard, or open a filled clipboard to drag items to the page.</source>
+			</trans-unit>
 			<trans-unit id="clipboardHeading" xml:space="preserve">
 				<source>Clipboard</source>
 			</trans-unit>
@@ -137,8 +140,14 @@
 			<trans-unit id="clipboardReference" xml:space="preserve">
 				<source>Reference element</source>
 			</trans-unit>
+			<trans-unit id="newCeWizardAriaLabel" xml:space="preserve">
+				<source>Click here to open the new content element wizard to add new content elements by dragging them to the page.</source>
+			</trans-unit>
 			<trans-unit id="newCeWizardDesc" xml:space="preserve">
 				<source>Please select the content type you want to add from the appropriate tab and drag and drop its icon to the desired position.</source>
+			</trans-unit>
+			<trans-unit id="trashAriaLabel" xml:space="preserve">
+				<source>You can drag items from the page to here to remove them, or open a filled trash to drag items back to the page to restore them.</source>
 			</trans-unit>
 			<trans-unit id="trashHeading" xml:space="preserve">
 				<source>Unused Elements</source>

--- a/Resources/Private/Templates/Backend/PageLayout/Show.html
+++ b/Resources/Private/Templates/Backend/PageLayout/Show.html
@@ -1,4 +1,5 @@
-{namespace core = TYPO3\CMS\Core\ViewHelpers}
+<html data-namespace-typo3-fluid="true" xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers" xmlns:tvp="Tvp\TemplaVoilaPlus\ViewHelpers">
+
 <f:if condition="{settings.configuration.is11orNewer}">
     <f:then>
         <f:be.pageRenderer
@@ -132,7 +133,8 @@
         <div id="tvpContentIntegrator" data-identifier="tvpContentIntegrator">
             <nav id="sidenav">
                 <ul class="sidenav-menu">
-                    <li class="sidenav-item disabled" id="navbarContentElementWizard">
+                    <li class="sidenav-item disabled" id="navbarContentElementWizard" draggable="false"
+                        {tvp:toolTipAttributes(text:'{f:translate(key:\'LLL:EXT:templavoilaplus/Resources/Private/Language/Backend/PageLayout.xlf:newCeWizardAriaLabel\')}',placement:'left')} >
                         <div>
                             <f:if condition="{settings.configuration.is10orNewer}">
                                 <f:then>
@@ -151,7 +153,8 @@
                             </div>
                         </li>
                     </f:if>
-                    <li class="sidenav-item {f:if(condition:'!{clipboard.tt_content.count}', then: 'disabled')} " id="navbarClipboard" data-clipboard-count="{clipboard.tt_content.count}">
+                    <li class="sidenav-item {f:if(condition:'!{clipboard.tt_content.count}', then: 'disabled')} " id="navbarClipboard" draggable="false" data-clipboard-count="{clipboard.tt_content.count}"
+                        {tvp:toolTipAttributes(text:'{f:translate(key:\'LLL:EXT:templavoilaplus/Resources/Private/Language/Backend/PageLayout.xlf:clipboardAriaLabel\')}',placement:'left')} >
                         <div>
                             <f:if condition="{settings.configuration.is10orNewer}">
                                 <f:then>
@@ -164,7 +167,8 @@
                             <span class="position-absolute translate-middle badge rounded-pill bg-success">{clipboard.tt_content.count}</span>
                         </div>
                     </li>
-                    <li class="sidenav-item {f:if(condition:'!{unused.tt_content.count}', then: 'disabled')} sidenav-item-trash" id="navbarTrash" data-unused-count="{unused.tt_content.count}">
+                    <li class="sidenav-item {f:if(condition:'!{unused.tt_content.count}', then: 'disabled')} sidenav-item-trash"  draggable="false" id="navbarTrash" data-unused-count="{unused.tt_content.count}"
+                        {tvp:toolTipAttributes(text:'{f:translate(key:\'LLL:EXT:templavoilaplus/Resources/Private/Language/Backend/PageLayout.xlf:trashAriaLabel\')}',placement:'left')} >
                         <div>
                             <core:icon identifier="actions-delete" size="default" /><span class="position-absolute translate-middle badge rounded-pill bg-danger">{unused.tt_content.count}</span>
                         </div>

--- a/Resources/Public/JavaScript/PageLayout.js
+++ b/Resources/Public/JavaScript/PageLayout.js
@@ -73,6 +73,7 @@ define([
                 name: 'dropzones',
                 put: true
             },
+            draggable: 'none',
             ghostClass: "hidden",
             onAdd: function (evt) {
                 // Remove from container later we may give the possibility for restoring before leaving page
@@ -99,6 +100,7 @@ define([
                 name: 'dropzones',
                 put: true
             },
+            draggable: 'none',
             ghostClass: "hidden",
             onAdd: function (evt) {
                 // Remove from container later we may give the possibility for restoring before leaving page


### PR DESCRIPTION
Bugfix: before the icon "clipboard" and "trash" could be dragged out of their sidebar nav item.

Addon: now we have bootstrap tooltips for the sidebar items to improve UX: a lot of editors asked how to delete stuff, thus a mouseover-info for the delete icon might help.

Added a tooltip helper which creates attributes based on TYPO3 version which can reduce number of condition in other partials, too.

![x](https://user-images.githubusercontent.com/12411176/197979645-ddf1930a-93c1-46a0-90c7-59fdbd0aef07.png)
