### PR TITLE
[BUGFIX] PHP8.1 optimization: valueProcessing typoScript throws exception

### DIFF
--- a/Classes/Handler/Mapping/DefaultMappingHandler.php
+++ b/Classes/Handler/Mapping/DefaultMappingHandler.php
@@ -62,7 +62,7 @@ class DefaultMappingHandler
             $GLOBALS['TSFE']->register['tx_templavoilaplus_pi1.current_field'] = $instructions['dataPath'];
         }
 
-        switch ($instructions['dataType']) {
+        switch ($instructions['dataType'] ?? null) {
             case 'row':
                 if (isset($row[$instructions['dataPath']])) {
                     $processedValue = $row[$instructions['dataPath']] ?? '';

--- a/Classes/Handler/Render/XpathRenderHandler.php
+++ b/Classes/Handler/Render/XpathRenderHandler.php
@@ -205,7 +205,7 @@ class XpathRenderHandler implements RenderHandlerInterface
             $processingNode->parentNode->removeChild($processingNode);
         }
 
-        switch ($mappingConfiguration['valueType']) {
+        switch ($mappingConfiguration['valueType'] ?? null) {
             case 'html':
                 if ($processedValues[$fieldName]) {
                     $tmpDoc = new \DOMDocument();


### PR DESCRIPTION
An FCE with a Mapping of
```
        field_heading:
            valueProcessing: typoScript
            valueProcessing.typoScript: |-
                10 = TEXT
                10.data = register:tx_templavoilaplus_pi1.parentRec.header
```
throws exceptions as `dataType` and `valueType` are undefined