### PR TITLE
[TASK] add exception handling for insertElement

### DIFF
--- a/Classes/Controller/Backend/Ajax/ContentElements.php
+++ b/Classes/Controller/Backend/Ajax/ContentElements.php
@@ -41,24 +41,23 @@ class ContentElements extends AbstractResponse
 
         /** @TODO LanguageHandling! */
         /** @TODO Should we hide every element on create as it isn't configured yet? */
-        $result = $processingService->insertElement(
-            $parameters['destinationPointer'] ?? '',
-            $parameters['elementRow'] ?? []
-        );
-
-        if ($result) {
-            return new JsonResponse([
-                'uid' => $result,
-                'nodeHtml' => $this->record2html('tt_content', $result, $parameters['destinationPointer']),
-            ]);
-        } else {
+        try {
+            $result = $processingService->insertElement(
+                $parameters['destinationPointer'] ?? '',
+                $parameters['elementRow'] ?? []
+            );
+        } catch (ProcessingException $e) {
             return new JsonResponse(
                 [
-                    'error' => $result
+                    'error' => $e->getMessage()
                 ],
                 400 /* Bad request */
             );
         }
+        return new JsonResponse([
+            'uid' => $result,
+            'nodeHtml' => $this->record2html('tt_content', $result, $parameters['destinationPointer']),
+        ]);
     }
 
     /**

--- a/Classes/Service/ProcessingService.php
+++ b/Classes/Service/ProcessingService.php
@@ -497,6 +497,7 @@ class ProcessingService
      * @param string $destinationPointerString Flexform pointer defining the parent location of the new element. Position refers to the element _after_ which the new element should be inserted. Position == 0 means before the first element.
      * @param array $elementRow Array of field keys and values for the new content element record
      * @return mixed The UID of the newly created record or FALSE if operation was not successful
+     * @throws ProcessingException
      */
     public function insertElement(string $destinationPointerString, array $elementRow)
     {
@@ -521,8 +522,12 @@ class ProcessingService
         $tce->process_datamap();
         $elementUid = $tce->substNEWwithIDs['NEW'];
 
+        if (count($tce->errorLog)) {
+            throw new ProcessingException('Could not insert element: '.$tce->errorLog[0],1679526931767);
+        }
+
         if (!$elementUid) {
-            return false;
+            throw new ProcessingException('Could not insert element.',1679526931768);
         }
 
         // insert record into destination


### PR DESCRIPTION
Got an install where due to a switch to utf8mb4 creating a tt_content threw an SQL exception, however TVP died silently.

This adds exception handling for insertElement, as done already for other stuff to show the exception in the error flash message