### PR TITLE
[BUGFIX] fixes #502

### DIFF
--- a/Classes/Controller/Backend/LinkBrowserController.php
+++ b/Classes/Controller/Backend/LinkBrowserController.php
@@ -17,8 +17,8 @@ class LinkBrowserController extends CoreLinkBrowserController
     {
         parent::initDocumentTemplate();
         
-		$pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-		$pageRenderer->addRequireJsConfiguration(
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $pageRenderer->addRequireJsConfiguration(
             [
                 'map' => [
                     '*' => ['TYPO3/CMS/Backend/FormEngineLinkBrowserAdapter' => PathUtility::getRelativePathTo(ExtensionManagementUtility::extPath('templavoilaplus')) . '/Resources/Public/JavaScript/FormEngineLinkBrowserAdapter']

--- a/Classes/Controller/Backend/LinkBrowserController.php
+++ b/Classes/Controller/Backend/LinkBrowserController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tvp\TemplaVoilaPlus\Controller\Backend;
+
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Backend\Controller\LinkBrowserController as CoreLinkBrowserController;
+
+class LinkBrowserController extends CoreLinkBrowserController
+{
+
+    protected function initDocumentTemplate()
+    {
+        parent::initDocumentTemplate();
+        
+		$pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+		$pageRenderer->addRequireJsConfiguration(
+            [
+                'map' => [
+                    '*' => ['TYPO3/CMS/Backend/FormEngineLinkBrowserAdapter' => PathUtility::getRelativePathTo(ExtensionManagementUtility::extPath('templavoilaplus')) . '/Resources/Public/JavaScript/FormEngineLinkBrowserAdapter']
+                ]
+            ]
+        );
+	}
+}

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -15,7 +15,7 @@ return [
         'access' => 'user,group',
         'target' => \Tvp\TemplaVoilaPlus\Controller\Backend\ModalHelperController::class . '::closeAction',
     ],
-	
+
     // Overwrite from core
     // Register link wizard
     'wizard_link' => [

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -1,4 +1,8 @@
 <?php
+$targetWizardLink = \TYPO3\CMS\Backend\Controller\LinkBrowserController::class . '::mainAction';
+if (version_compare(TYPO3_version, '11.0.0', '<')) {
+    $targetWizardLink = \Tvp\TemplaVoilaPlus\Controller\Backend\LinkBrowserController::class . '::mainAction';
+}
 
 /**
  * Definitions for routes provided by EXT:templavoilaplus
@@ -10,5 +14,12 @@ return [
         'path' => '/templavoilaplus/modalhelper/close',
         'access' => 'user,group',
         'target' => \Tvp\TemplaVoilaPlus\Controller\Backend\ModalHelperController::class . '::closeAction',
+    ],
+	
+    // Overwrite from core
+    // Register link wizard
+    'wizard_link' => [
+        'path' => '/wizard/link/browse',
+        'target' => $targetWizardLink
     ],
 ];


### PR DESCRIPTION
fixes #502

overwrite TYPO3\CMS\Backend\Controller\LinkBrowserController::initDocumentTemplate and add a requireJS configuration for mapping FormEngineLinkBrowserAdapter

This modification should be load this new code only for typo3 version < 11.
However, i tested it only for typo3 v. 10.
I didn't test it with typo3 version 11 or more, but it should work.