### PR TITLE
[BUGFIX] fix fallbacks for site configs without langid 0

### DIFF
--- a/Classes/Domain/Repository/Localization/LocalizationRepository.php
+++ b/Classes/Domain/Repository/Localization/LocalizationRepository.php
@@ -83,7 +83,7 @@ class LocalizationRepository
         }
         $baseRecord = BackendUtility::getRecordWSOL($table, $uid, '*', ' AND ' . $hiddenField . '=0');
         if ($language > 0 && $baseRecord) {
-            $l10nRecord = BackendUtility::getRecordLocalization($table, $uid, $language)[0];
+            $l10nRecord = BackendUtility::getRecordLocalization($table, $uid, $language)[0] ?? null;
             // sadly $l10nRecord doesn't allow additionalWhere, so we check for hidden afterwards
             if ($l10nRecord && $l10nRecord[$hiddenField] === 0) {
                 return $l10nRecord;

--- a/Classes/Utility/TemplaVoilaUtility.php
+++ b/Classes/Utility/TemplaVoilaUtility.php
@@ -179,8 +179,8 @@ final class TemplaVoilaUtility
             if (isset($languages[0])) {
                 // If default Language already is set
                 // Take title and flag from default language
-                $languages[0]['title'] = $languageRecords[0]['title'];
-                $languages[0]['flagIcon'] = $languageRecords[0]['flagIcon'];
+                $languages[0]['title'] = $languageRecords[array_key_first($languageRecords)]['title'];
+                $languages[0]['flagIcon'] = $languageRecords[array_key_first($languageRecords)]['flagIcon'];
                 unset($languageRecords[0]);
             }
             $languages += $languageRecords;


### PR DESCRIPTION
Many parts of the l10n-code have the assumption that a language 0 exists.
However that doesn't need to be the case. Core defines that else the first defined language should be used.