### PR TITLE
[BUGFIX] possibly invalid foreach

### DIFF
--- a/Classes/Service/DataHandling/DataHandler.php
+++ b/Classes/Service/DataHandling/DataHandler.php
@@ -149,11 +149,13 @@ class DataHandler
                         /** @TODO getNodeWithTree is strange to get all usedElements and their pointers */
                         $nodes = $processingService->getNodeWithTree('pages', $page, $parentPointer, $record['pid'], $usedElements);
 
-                        foreach ($usedElements[$table] as $usedUid => $elementConfig) {
-                            if ($id == $usedUid) {
-                                /** @TODO We should unlink every pointer but the position inside pointer will change after first unlink */
-                                if (isset($elementConfig['parentPointers'][0])) {
-                                    $processingService->unlinkElement($elementConfig['parentPointers'][0]);
+                        if (isset($usedElements[$table]) && is_array($usedElements[$table])) {
+                            foreach ($usedElements[$table] as $usedUid => $elementConfig) {
+                                if ($id == $usedUid) {
+                                    /** @TODO We should unlink every pointer but the position inside pointer will change after first unlink */
+                                    if (isset($elementConfig['parentPointers'][0])) {
+                                        $processingService->unlinkElement($elementConfig['parentPointers'][0]);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
While working with two editors on the same page editing and moving around stuff at the same time both editors ran into an error:
`Core: Error handler (BE): PHP Warning: Invalid argument supplied for foreach() in /typo3conf/ext/templavoilaplus/Classes/Service/DataHandling/DataHandler.php line 152`

Probably a race condition, probably during clipboard or recycler stuff, nevertheless easy to fix.