### PR TITLE
[FEATURE] refactor LinkBrowserController fix from #510

### DIFF
--- a/Classes/Controller/Backend/LinkBrowserController.php
+++ b/Classes/Controller/Backend/LinkBrowserController.php
@@ -16,12 +16,21 @@ class LinkBrowserController extends CoreLinkBrowserController
     {
         parent::initDocumentTemplate();
         $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-        $pageRenderer->addRequireJsConfiguration(
-            [
-                'map' => [
-                    '*' => ['TYPO3/CMS/Backend/FormEngineLinkBrowserAdapter' => PathUtility::getRelativePathTo(ExtensionManagementUtility::extPath('templavoilaplus')) . '/Resources/Public/JavaScript/FormEngineLinkBrowserAdapter']
+        if (version_compare(TYPO3_version, '10.4', '<=')) {
+            $pageRenderer->addRequireJsConfiguration(
+                [
+                    'map' => [
+                        '*' => [
+                            'TYPO3/CMS/Backend/FormEngineLinkBrowserAdapter' => PathUtility::getRelativePathTo(
+                                    ExtensionManagementUtility::extPath('templavoilaplus')
+                                ) .
+                                '/Resources/Public/JavaScript/FormEngineLinkBrowserAdapter'
+                        ]
+                    ]
                 ]
-            ]
-        );
+            );
+        } else {
+            $pageRenderer->loadRequireJsModule('TYPO3/CMS/Templavoilaplus/ParentWindow');
+        }
     }
 }

--- a/Classes/Core/Page/JavaScriptModuleInstruction.php
+++ b/Classes/Core/Page/JavaScriptModuleInstruction.php
@@ -36,7 +36,9 @@ class JavaScriptModuleInstruction extends CoreJavaScriptModuleInstruction
      */
     public function __construct(string $name, int $flags)
     {
-        $name = preg_replace($this->pattern, $this->replace, $name);
+        if (version_compare(TYPO3_version, '10.4', '<=')) {
+            $name = preg_replace($this->pattern, $this->replace, $name);
+        }
         parent::__construct($name, $flags);
     }
 }

--- a/Resources/Public/JavaScript/ParentWindow.js
+++ b/Resources/Public/JavaScript/ParentWindow.js
@@ -1,0 +1,20 @@
+define([
+  'TYPO3/CMS/Backend/FormEngineLinkBrowserAdapter'
+], function(FormEngineLinkBrowserAdapter, ElementBrowser) {
+  const FormEngineLinkBrowserAdapterParentFunction = FormEngineLinkBrowserAdapter.getParent;
+  const getParent = () => {
+	if (
+      typeof window.parent !== 'undefined' &&
+      typeof window.parent.document.list_frame !== 'undefined' &&
+      window.parent.frames.list_frame.parent.document.querySelector('.t3js-modal-iframe') !== null &&
+      window.parent.frames.list_frame.parent.document.querySelectorAll('.t3js-modal-iframe').length > 1
+    ) {
+	  return window.parent.frames.list_frame.parent.document.querySelector('.t3js-modal-iframe').contentWindow;
+    }
+    return null;
+  }
+
+  FormEngineLinkBrowserAdapter.getParent = () => {
+    return getParent() || FormEngineLinkBrowserAdapterParentFunction();
+  }
+});

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,6 +8,9 @@ defined('TYPO3_MODE') or die();
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools::class]['className']
     = \Tvp\TemplaVoilaPlus\Configuration\FlexForm\FlexFormTools8::class;
 
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Backend\Controller\LinkBrowserController::class]['className']
+    = Tvp\TemplaVoilaPlus\Controller\Backend\LinkBrowserController::class;
+
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][TYPO3\CMS\Core\Page\JavaScriptModuleInstruction::class]['className']
     = Tvp\TemplaVoilaPlus\Core\Page\JavaScriptModuleInstruction::class;
 


### PR DESCRIPTION
Didn't test myself in pre-11, but the code is quite clear. The new solution resolves regressions with the LinkBrowser if the later is used e.g. in list module (changes were not transferred, same error TVP page module had, so we just traded one problem for another).

As requested in https://github.com/T3Voila/templavoilaplus/pull/510#pullrequestreview-1553649759:
Providing new variant for >=11 and retaining old solution for <=10

fixes #510, fixes #502, rels #503, rels #507, rels #508

backport 8.1.x