### PR TITLE
[REGRESSION] Fix rowList

### DIFF
--- a/Classes/Handler/Mapping/DefaultMappingHandler.php
+++ b/Classes/Handler/Mapping/DefaultMappingHandler.php
@@ -102,9 +102,7 @@ class DefaultMappingHandler
                 }
                 break;
             case 'rowList':
-                if (is_array($processedValue)) {
-                    $processedValue = $this->processRowList($processedValue, $table, $row);
-                }
+                $processedValue = $this->processRowList($processedValue, $table, $row);
                 break;
             case 'stdWrap':
                 break;


### PR DESCRIPTION
During the recent merge from 8.1.x to 8.2.x (https://github.com/T3Voila/templavoilaplus/commit/6025ea931a8632b894dbda92a4bf57c3d0282727) some bugfix was overridden and created a regression (FCE columns showed a list of uids for each field/column, instead of array of records). 

The same line in main also has no if-clause.

Here is the old commit for reference https://github.com/T3Voila/templavoilaplus/commit/feae6a3444938501265504dfb37e00df71e0d302 which removed the if.

Thus, I propose to remove it again.