### PR TITLE
[TASK] Update phpstan-baseline.neon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -232,7 +232,7 @@
         "npm:init": [
             "@yarn:init"
         ],
-        "phpstan:baseline": ".Build/bin/phpstan  --generate-baseline=phpstan-baseline.neon",
+        "phpstan:baseline": ".Build/bin/phpstan  --generate-baseline=phpstan-baseline.neon --level 0",
         "prepare-release": [
             "rm .gitignore",
             "rm -rf .Build",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: Classes/Configuration/BackendConfiguration.php
 
 		-
-			message: "#^Undefined variable\\: \\$dataStructArray$#"
-			count: 2
-			path: Classes/Configuration/FlexForm/FlexFormTools8.php
-
-		-
 			message: "#^Call to static method makeInstance\\(\\) on an unknown class Tvp\\\\TemplaVoilaPlus\\\\Controller\\\\Backend\\\\Handler\\\\GeneralUtility\\.$#"
 			count: 1
 			path: Classes/Controller/Backend/Handler/DoktypeMountpointHandler.php


### PR DESCRIPTION
This patch removes one unmatched error pattern,
which seems to be fixed meanwhile.

In addition, the composer script for generating
the baseline has an added "--level 0" option so
that it aligns with the CI pipeline.