### PR TITLE
[REGRESSION] method signature mismatch

### DIFF
--- a/Classes/Handler/Render/XpathRenderHandler.php
+++ b/Classes/Handler/Render/XpathRenderHandler.php
@@ -17,7 +17,6 @@ namespace Tvp\TemplaVoilaPlus\Handler\Render;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Psr\Http\Message\ServerRequestInterface;
 use Tvp\TemplaVoilaPlus\Domain\Model\Configuration\TemplateConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -30,7 +29,7 @@ class XpathRenderHandler implements RenderHandlerInterface
     protected $domDocument;
     protected $domXpath;
 
-    public function renderTemplate(TemplateConfiguration $templateConfiguration, array $processedValues, array $row, ServerRequestInterface $request): string
+    public function renderTemplate(TemplateConfiguration $templateConfiguration, array $processedValues, array $row): string
     {
         $this->domDocument = new \DOMDocument();
         libxml_use_internal_errors(true);


### PR DESCRIPTION
RenderHandlerInterface::renderTemplate() doesn't have $request in 8.2.x, was added in main.

Adding it now would break EXT:tvplus-fluid. As $request is not used anyways yet, just dropping it.