### PR TITLE
Fix FlexFormTools callbackFunction

### DIFF
--- a/Classes/Configuration/FlexForm/FlexFormTools8.php
+++ b/Classes/Configuration/FlexForm/FlexFormTools8.php
@@ -334,35 +334,4 @@ class FlexFormTools8 extends \TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTool
         }
         return $dataStructureIdentifier;
     }
-
-    /***********************************
-     *
-     * Processing functions
-     *
-     ***********************************/
-    /**
-     * Call back function for \TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools class
-     * Basically just setting the value in a new array (thus cleaning because only values that are valid are visited!)
-     *
-     * @param array $dsArr Data structure for the current value
-     * @param mixed $data Current value
-     * @param array $PA Additional configuration used in calling function
-     * @param string $path Path of value in DS structure
-     * @param FlexFormTools $pObj caller
-     */
-    // phpcs:disable PSR1.Methods.CamelCapsMethodName
-    public function cleanFlexFormXML_callBackFunction($dsArr, $data, $PA, $path, $pObj)
-    {
-        // phpcs:enable
-        // Just setting value in our own result array, basically replicating the structure:
-        ArrayUtility::setValueByPath($this->cleanFlexFormXML, $path, $data);
-        // Looking if an "extension" called ".vDEFbase" is found and if so, accept that too:
-        if ($GLOBALS['TYPO3_CONF_VARS']['BE']['flexFormXMLincludeDiffBase']) {
-            $vDEFbase = ArrayUtility::getValueByPath($pObj->traverseFlexFormXMLData_Data, $path . '.vDEFbase');
-            if (isset($vDEFbase)) {
-                ArrayUtility::setValueByPath($this->cleanFlexFormXML, $path . '.vDEFbase', $vDEFbase);
-            }
-        }
-    }
-
 }

--- a/Classes/Configuration/FlexForm/FlexFormTools8.php
+++ b/Classes/Configuration/FlexForm/FlexFormTools8.php
@@ -28,6 +28,7 @@ use TYPO3\CMS\Core\Configuration\FlexForm\Exception\InvalidSinglePointerFieldExc
 use TYPO3\CMS\Core\Configuration\FlexForm\Exception\InvalidTcaException;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 
@@ -354,13 +355,14 @@ class FlexFormTools8 extends \TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTool
     {
         // phpcs:enable
         // Just setting value in our own result array, basically replicating the structure:
-        $pObj->setArrayValueByPath($path, $this->cleanFlexFormXML, $data);
+        ArrayUtility::setValueByPath($this->cleanFlexFormXML, $path, $data);
         // Looking if an "extension" called ".vDEFbase" is found and if so, accept that too:
         if ($GLOBALS['TYPO3_CONF_VARS']['BE']['flexFormXMLincludeDiffBase']) {
-            $vDEFbase = $pObj->getArrayValueByPath($path . '.vDEFbase', $pObj->traverseFlexFormXMLData_Data);
+            $vDEFbase = ArrayUtility::getValueByPath($pObj->traverseFlexFormXMLData_Data, $path . '.vDEFbase');
             if (isset($vDEFbase)) {
-                $pObj->setArrayValueByPath($path . '.vDEFbase', $this->cleanFlexFormXML, $vDEFbase);
+                ArrayUtility::setValueByPath($this->cleanFlexFormXML, $path . '.vDEFbase', $vDEFbase);
             }
         }
     }
+
 }


### PR DESCRIPTION
During 12LTS migration an EXT:cal upgrade wizard failed because FlexFormTools8::cleanFlexFormXML_callBackFunction() created an exception.

After applying the migration path from https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95254-TwoFlexFormToolsMethods.html to fix that exception the further calls relied on an `$pObj->traverseFlexFormXMLData_Data` which I couldn't resolve to anything. So probably as of time of writing this was always null and probably thus nothing much was done in that `if`. The remainder of the function is from the base function, so I propose to just delete it.

While that resolves my updater issues, I don't have enough insight to prove that there are no race conditions from this, so please check this
 ¯\\\_(ツ)\_/¯