### PR TITLE
Test Optimization: fix 2 sniffs and add PHP 8.3 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version:
-          - 8.1
-          - 8.2
+        php-version: [ '8.1', '8.2', '8.3' ]
   code-quality:
     name: "Code quality checks"
     runs-on: ubuntu-22.04
@@ -64,7 +62,7 @@ jobs:
           - "php:stan"
           - "ts:lint"
           - "yaml:lint"
-        php-version: [ '8.1', '8.2' ]
+        php-version: [ '8.1', '8.2', '8.3' ]
   code-quality-frontend:
     name: "Code quality frontend checks"
     runs-on: ubuntu-22.04
@@ -94,7 +92,7 @@ jobs:
     needs: php-lint
     strategy:
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Classes/Controller/Frontend/PageBasicsHandler.php
+++ b/Classes/Controller/Frontend/PageBasicsHandler.php
@@ -24,8 +24,10 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 class PageBasicsHandler
 {
+    // phpcs:disable Generic.Metrics.CyclomaticComplexity
     public static function processConfiguration(TemplateConfiguration $templateConfiguration, TypoScriptFrontendController $controller)
     {
+        // phpcs:enable
         $headerConfiguration = $templateConfiguration->getHeader();
 
         /** @var PageRenderer */

--- a/Classes/Service/DataHandling/DataHandler.php
+++ b/Classes/Service/DataHandling/DataHandler.php
@@ -128,8 +128,10 @@ class DataHandler
                     )
                 ) {
                     $reference->newlog(
-                        sprintf($this->getLanguageService()->sL(
-                            'LLL:EXT:templavoilaplus/Resources/Private/Language/locallang_access.xlf:access_noModifyAccess'),
+                        sprintf(
+                            $this->getLanguageService()->sL(
+                                'LLL:EXT:templavoilaplus/Resources/Private/Language/locallang_access.xlf:access_noModifyAccess'
+                            ),
                             $table,
                             $id
                         ),


### PR DESCRIPTION
PHP 8.4 tests would need a revamp of the dependencies, so skipped for now